### PR TITLE
Only support text based querying and authentication methods.

### DIFF
--- a/gen/c/surrealdb/protocol/rpc/v1/rpc.pb-c.c
+++ b/gen/c/surrealdb/protocol/rpc/v1/rpc.pb-c.c
@@ -187,186 +187,6 @@ void   surrealdb__protocol__rpc__v1__version_response__free_unpacked
   assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__version_response__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   surrealdb__protocol__rpc__v1__info_request__init
-                     (Surrealdb__Protocol__Rpc__V1__InfoRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__InfoRequest init_value = SURREALDB__PROTOCOL__RPC__V1__INFO_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__info_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InfoRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__info_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__info_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InfoRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__info_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__info_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InfoRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__info_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__InfoRequest *
-       surrealdb__protocol__rpc__v1__info_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__InfoRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__info_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__info_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InfoRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__info_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__info_response__init
-                     (Surrealdb__Protocol__Rpc__V1__InfoResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__InfoResponse init_value = SURREALDB__PROTOCOL__RPC__V1__INFO_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__info_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InfoResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__info_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__info_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InfoResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__info_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__info_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InfoResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__info_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__InfoResponse *
-       surrealdb__protocol__rpc__v1__info_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__InfoResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__info_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__info_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InfoResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__info_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__use_request__init
-                     (Surrealdb__Protocol__Rpc__V1__UseRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__UseRequest init_value = SURREALDB__PROTOCOL__RPC__V1__USE_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__use_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UseRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__use_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UseRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__use_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UseRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__UseRequest *
-       surrealdb__protocol__rpc__v1__use_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__UseRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__use_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__use_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UseRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__use_response__init
-                     (Surrealdb__Protocol__Rpc__V1__UseResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__UseResponse init_value = SURREALDB__PROTOCOL__RPC__V1__USE_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__use_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UseResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__use_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UseResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__use_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UseResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__UseResponse *
-       surrealdb__protocol__rpc__v1__use_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__UseResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__use_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__use_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UseResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
 void   surrealdb__protocol__rpc__v1__signup_request__init
                      (Surrealdb__Protocol__Rpc__V1__SignupRequest         *message)
 {
@@ -637,1039 +457,139 @@ void   surrealdb__protocol__rpc__v1__authenticate_response__free_unpacked
   assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__authenticate_response__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   surrealdb__protocol__rpc__v1__invalidate_request__init
-                     (Surrealdb__Protocol__Rpc__V1__InvalidateRequest         *message)
+void   surrealdb__protocol__rpc__v1__subscribe_request__init
+                     (Surrealdb__Protocol__Rpc__V1__SubscribeRequest         *message)
 {
-  static const Surrealdb__Protocol__Rpc__V1__InvalidateRequest init_value = SURREALDB__PROTOCOL__RPC__V1__INVALIDATE_REQUEST__INIT;
+  static const Surrealdb__Protocol__Rpc__V1__SubscribeRequest init_value = SURREALDB__PROTOCOL__RPC__V1__SUBSCRIBE_REQUEST__INIT;
   *message = init_value;
 }
-size_t surrealdb__protocol__rpc__v1__invalidate_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateRequest *message)
+size_t surrealdb__protocol__rpc__v1__subscribe_request__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeRequest *message)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__invalidate_request__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__subscribe_request__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t surrealdb__protocol__rpc__v1__invalidate_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateRequest *message,
+size_t surrealdb__protocol__rpc__v1__subscribe_request__pack
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeRequest *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__invalidate_request__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__subscribe_request__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t surrealdb__protocol__rpc__v1__invalidate_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateRequest *message,
+size_t surrealdb__protocol__rpc__v1__subscribe_request__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeRequest *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__invalidate_request__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__subscribe_request__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-Surrealdb__Protocol__Rpc__V1__InvalidateRequest *
-       surrealdb__protocol__rpc__v1__invalidate_request__unpack
+Surrealdb__Protocol__Rpc__V1__SubscribeRequest *
+       surrealdb__protocol__rpc__v1__subscribe_request__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (Surrealdb__Protocol__Rpc__V1__InvalidateRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__invalidate_request__descriptor,
+  return (Surrealdb__Protocol__Rpc__V1__SubscribeRequest *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__subscribe_request__descriptor,
                                 allocator, len, data);
 }
-void   surrealdb__protocol__rpc__v1__invalidate_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InvalidateRequest *message,
+void   surrealdb__protocol__rpc__v1__subscribe_request__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__SubscribeRequest *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__invalidate_request__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__subscribe_request__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   surrealdb__protocol__rpc__v1__invalidate_response__init
-                     (Surrealdb__Protocol__Rpc__V1__InvalidateResponse         *message)
+void   surrealdb__protocol__rpc__v1__subscribe_response__init
+                     (Surrealdb__Protocol__Rpc__V1__SubscribeResponse         *message)
 {
-  static const Surrealdb__Protocol__Rpc__V1__InvalidateResponse init_value = SURREALDB__PROTOCOL__RPC__V1__INVALIDATE_RESPONSE__INIT;
+  static const Surrealdb__Protocol__Rpc__V1__SubscribeResponse init_value = SURREALDB__PROTOCOL__RPC__V1__SUBSCRIBE_RESPONSE__INIT;
   *message = init_value;
 }
-size_t surrealdb__protocol__rpc__v1__invalidate_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateResponse *message)
+size_t surrealdb__protocol__rpc__v1__subscribe_response__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeResponse *message)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__invalidate_response__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__subscribe_response__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t surrealdb__protocol__rpc__v1__invalidate_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateResponse *message,
+size_t surrealdb__protocol__rpc__v1__subscribe_response__pack
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeResponse *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__invalidate_response__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__subscribe_response__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t surrealdb__protocol__rpc__v1__invalidate_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateResponse *message,
+size_t surrealdb__protocol__rpc__v1__subscribe_response__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeResponse *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__invalidate_response__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__subscribe_response__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-Surrealdb__Protocol__Rpc__V1__InvalidateResponse *
-       surrealdb__protocol__rpc__v1__invalidate_response__unpack
+Surrealdb__Protocol__Rpc__V1__SubscribeResponse *
+       surrealdb__protocol__rpc__v1__subscribe_response__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (Surrealdb__Protocol__Rpc__V1__InvalidateResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__invalidate_response__descriptor,
+  return (Surrealdb__Protocol__Rpc__V1__SubscribeResponse *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__subscribe_response__descriptor,
                                 allocator, len, data);
 }
-void   surrealdb__protocol__rpc__v1__invalidate_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InvalidateResponse *message,
+void   surrealdb__protocol__rpc__v1__subscribe_response__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__SubscribeResponse *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__invalidate_response__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__subscribe_response__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   surrealdb__protocol__rpc__v1__reset_request__init
-                     (Surrealdb__Protocol__Rpc__V1__ResetRequest         *message)
+void   surrealdb__protocol__rpc__v1__notification__init
+                     (Surrealdb__Protocol__Rpc__V1__Notification         *message)
 {
-  static const Surrealdb__Protocol__Rpc__V1__ResetRequest init_value = SURREALDB__PROTOCOL__RPC__V1__RESET_REQUEST__INIT;
+  static const Surrealdb__Protocol__Rpc__V1__Notification init_value = SURREALDB__PROTOCOL__RPC__V1__NOTIFICATION__INIT;
   *message = init_value;
 }
-size_t surrealdb__protocol__rpc__v1__reset_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest *message)
+size_t surrealdb__protocol__rpc__v1__notification__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__Notification *message)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_request__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__notification__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t surrealdb__protocol__rpc__v1__reset_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest *message,
+size_t surrealdb__protocol__rpc__v1__notification__pack
+                     (const Surrealdb__Protocol__Rpc__V1__Notification *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_request__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__notification__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t surrealdb__protocol__rpc__v1__reset_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest *message,
+size_t surrealdb__protocol__rpc__v1__notification__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__Notification *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_request__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__notification__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-Surrealdb__Protocol__Rpc__V1__ResetRequest *
-       surrealdb__protocol__rpc__v1__reset_request__unpack
+Surrealdb__Protocol__Rpc__V1__Notification *
+       surrealdb__protocol__rpc__v1__notification__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (Surrealdb__Protocol__Rpc__V1__ResetRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__reset_request__descriptor,
+  return (Surrealdb__Protocol__Rpc__V1__Notification *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__notification__descriptor,
                                 allocator, len, data);
 }
-void   surrealdb__protocol__rpc__v1__reset_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__ResetRequest *message,
+void   surrealdb__protocol__rpc__v1__notification__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__Notification *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__reset_response__init
-                     (Surrealdb__Protocol__Rpc__V1__ResetResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__ResetResponse init_value = SURREALDB__PROTOCOL__RPC__V1__RESET_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__reset_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__reset_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__reset_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__ResetResponse *
-       surrealdb__protocol__rpc__v1__reset_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__ResetResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__reset_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__reset_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__ResetResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__kill_request__init
-                     (Surrealdb__Protocol__Rpc__V1__KillRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__KillRequest init_value = SURREALDB__PROTOCOL__RPC__V1__KILL_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__kill_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__KillRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__kill_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__kill_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__KillRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__kill_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__kill_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__KillRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__kill_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__KillRequest *
-       surrealdb__protocol__rpc__v1__kill_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__KillRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__kill_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__kill_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__KillRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__kill_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__kill_response__init
-                     (Surrealdb__Protocol__Rpc__V1__KillResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__KillResponse init_value = SURREALDB__PROTOCOL__RPC__V1__KILL_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__kill_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__KillResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__kill_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__kill_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__KillResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__kill_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__kill_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__KillResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__kill_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__KillResponse *
-       surrealdb__protocol__rpc__v1__kill_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__KillResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__kill_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__kill_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__KillResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__kill_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__live_request__init
-                     (Surrealdb__Protocol__Rpc__V1__LiveRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__LiveRequest init_value = SURREALDB__PROTOCOL__RPC__V1__LIVE_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__live_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__LiveRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__live_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__live_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__LiveRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__live_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__live_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__LiveRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__live_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__LiveRequest *
-       surrealdb__protocol__rpc__v1__live_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__LiveRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__live_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__live_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__LiveRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__live_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__set_request__init
-                     (Surrealdb__Protocol__Rpc__V1__SetRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__SetRequest init_value = SURREALDB__PROTOCOL__RPC__V1__SET_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__set_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__SetRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__set_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__SetRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__set_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__SetRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__SetRequest *
-       surrealdb__protocol__rpc__v1__set_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__SetRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__set_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__set_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__SetRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__set_response__init
-                     (Surrealdb__Protocol__Rpc__V1__SetResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__SetResponse init_value = SURREALDB__PROTOCOL__RPC__V1__SET_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__set_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__SetResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__set_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__SetResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__set_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__SetResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__SetResponse *
-       surrealdb__protocol__rpc__v1__set_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__SetResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__set_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__set_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__SetResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__unset_request__init
-                     (Surrealdb__Protocol__Rpc__V1__UnsetRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__UnsetRequest init_value = SURREALDB__PROTOCOL__RPC__V1__UNSET_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__unset_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__unset_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__unset_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__UnsetRequest *
-       surrealdb__protocol__rpc__v1__unset_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__UnsetRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__unset_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__unset_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UnsetRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__unset_response__init
-                     (Surrealdb__Protocol__Rpc__V1__UnsetResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__UnsetResponse init_value = SURREALDB__PROTOCOL__RPC__V1__UNSET_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__unset_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__unset_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__unset_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__UnsetResponse *
-       surrealdb__protocol__rpc__v1__unset_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__UnsetResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__unset_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__unset_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UnsetResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__create_request__init
-                     (Surrealdb__Protocol__Rpc__V1__CreateRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__CreateRequest init_value = SURREALDB__PROTOCOL__RPC__V1__CREATE_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__create_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__CreateRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__create_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__create_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__CreateRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__create_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__create_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__CreateRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__create_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__CreateRequest *
-       surrealdb__protocol__rpc__v1__create_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__CreateRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__create_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__create_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__CreateRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__create_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__create_response__init
-                     (Surrealdb__Protocol__Rpc__V1__CreateResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__CreateResponse init_value = SURREALDB__PROTOCOL__RPC__V1__CREATE_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__create_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__CreateResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__create_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__create_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__CreateResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__create_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__create_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__CreateResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__create_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__CreateResponse *
-       surrealdb__protocol__rpc__v1__create_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__CreateResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__create_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__create_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__CreateResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__create_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__select_request__init
-                     (Surrealdb__Protocol__Rpc__V1__SelectRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__SelectRequest init_value = SURREALDB__PROTOCOL__RPC__V1__SELECT_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__select_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__SelectRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__select_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__select_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__SelectRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__select_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__select_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__SelectRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__select_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__SelectRequest *
-       surrealdb__protocol__rpc__v1__select_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__SelectRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__select_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__select_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__SelectRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__select_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__select_response__init
-                     (Surrealdb__Protocol__Rpc__V1__SelectResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__SelectResponse init_value = SURREALDB__PROTOCOL__RPC__V1__SELECT_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__select_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__SelectResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__select_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__select_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__SelectResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__select_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__select_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__SelectResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__select_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__SelectResponse *
-       surrealdb__protocol__rpc__v1__select_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__SelectResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__select_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__select_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__SelectResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__select_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__insert_request__init
-                     (Surrealdb__Protocol__Rpc__V1__InsertRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__InsertRequest init_value = SURREALDB__PROTOCOL__RPC__V1__INSERT_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__insert_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InsertRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__insert_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__insert_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InsertRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__insert_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__insert_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InsertRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__insert_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__InsertRequest *
-       surrealdb__protocol__rpc__v1__insert_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__InsertRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__insert_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__insert_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InsertRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__insert_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__insert_response__init
-                     (Surrealdb__Protocol__Rpc__V1__InsertResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__InsertResponse init_value = SURREALDB__PROTOCOL__RPC__V1__INSERT_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__insert_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InsertResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__insert_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__insert_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InsertResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__insert_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__insert_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InsertResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__insert_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__InsertResponse *
-       surrealdb__protocol__rpc__v1__insert_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__InsertResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__insert_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__insert_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InsertResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__insert_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__upsert_request__init
-                     (Surrealdb__Protocol__Rpc__V1__UpsertRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__UpsertRequest init_value = SURREALDB__PROTOCOL__RPC__V1__UPSERT_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__upsert_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__upsert_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__upsert_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__upsert_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__upsert_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__upsert_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__UpsertRequest *
-       surrealdb__protocol__rpc__v1__upsert_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__UpsertRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__upsert_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__upsert_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UpsertRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__upsert_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__upsert_response__init
-                     (Surrealdb__Protocol__Rpc__V1__UpsertResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__UpsertResponse init_value = SURREALDB__PROTOCOL__RPC__V1__UPSERT_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__upsert_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__upsert_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__upsert_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__upsert_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__upsert_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__upsert_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__UpsertResponse *
-       surrealdb__protocol__rpc__v1__upsert_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__UpsertResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__upsert_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__upsert_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UpsertResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__upsert_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__update_request__init
-                     (Surrealdb__Protocol__Rpc__V1__UpdateRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__UpdateRequest init_value = SURREALDB__PROTOCOL__RPC__V1__UPDATE_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__update_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__update_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__update_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__update_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__update_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__update_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__UpdateRequest *
-       surrealdb__protocol__rpc__v1__update_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__UpdateRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__update_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__update_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UpdateRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__update_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__update_response__init
-                     (Surrealdb__Protocol__Rpc__V1__UpdateResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__UpdateResponse init_value = SURREALDB__PROTOCOL__RPC__V1__UPDATE_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__update_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__update_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__update_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__update_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__update_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__update_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__UpdateResponse *
-       surrealdb__protocol__rpc__v1__update_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__UpdateResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__update_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__update_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UpdateResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__update_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__delete_request__init
-                     (Surrealdb__Protocol__Rpc__V1__DeleteRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__DeleteRequest init_value = SURREALDB__PROTOCOL__RPC__V1__DELETE_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__delete_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__delete_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__delete_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__delete_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__delete_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__delete_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__DeleteRequest *
-       surrealdb__protocol__rpc__v1__delete_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__DeleteRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__delete_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__delete_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__DeleteRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__delete_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__delete_response__init
-                     (Surrealdb__Protocol__Rpc__V1__DeleteResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__DeleteResponse init_value = SURREALDB__PROTOCOL__RPC__V1__DELETE_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__delete_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__delete_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__delete_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__delete_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__delete_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__delete_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__DeleteResponse *
-       surrealdb__protocol__rpc__v1__delete_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__DeleteResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__delete_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__delete_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__DeleteResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__delete_response__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__notification__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
 void   surrealdb__protocol__rpc__v1__query_request__init
@@ -1807,229 +727,49 @@ void   surrealdb__protocol__rpc__v1__query_stats__free_unpacked
   assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__query_stats__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   surrealdb__protocol__rpc__v1__relate_request__init
-                     (Surrealdb__Protocol__Rpc__V1__RelateRequest         *message)
+void   surrealdb__protocol__rpc__v1__query_error__init
+                     (Surrealdb__Protocol__Rpc__V1__QueryError         *message)
 {
-  static const Surrealdb__Protocol__Rpc__V1__RelateRequest init_value = SURREALDB__PROTOCOL__RPC__V1__RELATE_REQUEST__INIT;
+  static const Surrealdb__Protocol__Rpc__V1__QueryError init_value = SURREALDB__PROTOCOL__RPC__V1__QUERY_ERROR__INIT;
   *message = init_value;
 }
-size_t surrealdb__protocol__rpc__v1__relate_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__RelateRequest *message)
+size_t surrealdb__protocol__rpc__v1__query_error__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__QueryError *message)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__relate_request__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__query_error__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t surrealdb__protocol__rpc__v1__relate_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__RelateRequest *message,
+size_t surrealdb__protocol__rpc__v1__query_error__pack
+                     (const Surrealdb__Protocol__Rpc__V1__QueryError *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__relate_request__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__query_error__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t surrealdb__protocol__rpc__v1__relate_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__RelateRequest *message,
+size_t surrealdb__protocol__rpc__v1__query_error__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__QueryError *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__relate_request__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__query_error__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-Surrealdb__Protocol__Rpc__V1__RelateRequest *
-       surrealdb__protocol__rpc__v1__relate_request__unpack
+Surrealdb__Protocol__Rpc__V1__QueryError *
+       surrealdb__protocol__rpc__v1__query_error__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (Surrealdb__Protocol__Rpc__V1__RelateRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__relate_request__descriptor,
+  return (Surrealdb__Protocol__Rpc__V1__QueryError *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__query_error__descriptor,
                                 allocator, len, data);
 }
-void   surrealdb__protocol__rpc__v1__relate_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__RelateRequest *message,
+void   surrealdb__protocol__rpc__v1__query_error__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__QueryError *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__relate_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__relate_response__init
-                     (Surrealdb__Protocol__Rpc__V1__RelateResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__RelateResponse init_value = SURREALDB__PROTOCOL__RPC__V1__RELATE_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__relate_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__RelateResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__relate_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__relate_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__RelateResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__relate_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__relate_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__RelateResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__relate_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__RelateResponse *
-       surrealdb__protocol__rpc__v1__relate_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__RelateResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__relate_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__relate_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__RelateResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__relate_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__run_function_request__init
-                     (Surrealdb__Protocol__Rpc__V1__RunFunctionRequest         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest init_value = SURREALDB__PROTOCOL__RPC__V1__RUN_FUNCTION_REQUEST__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__run_function_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__run_function_request__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__run_function_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__run_function_request__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__run_function_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__run_function_request__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *
-       surrealdb__protocol__rpc__v1__run_function_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__run_function_request__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__run_function_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__run_function_request__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__run_function_response__init
-                     (Surrealdb__Protocol__Rpc__V1__RunFunctionResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__RunFunctionResponse init_value = SURREALDB__PROTOCOL__RPC__V1__RUN_FUNCTION_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__run_function_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__run_function_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__run_function_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__run_function_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__run_function_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__run_function_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__RunFunctionResponse *
-       surrealdb__protocol__rpc__v1__run_function_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__RunFunctionResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__run_function_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__run_function_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__RunFunctionResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__run_function_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
-void   surrealdb__protocol__rpc__v1__value_batch__init
-                     (Surrealdb__Protocol__Rpc__V1__ValueBatch         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__ValueBatch init_value = SURREALDB__PROTOCOL__RPC__V1__VALUE_BATCH__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__value_batch__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__ValueBatch *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__value_batch__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__value_batch__pack
-                     (const Surrealdb__Protocol__Rpc__V1__ValueBatch *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__value_batch__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__value_batch__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__ValueBatch *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__value_batch__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__ValueBatch *
-       surrealdb__protocol__rpc__v1__value_batch__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__ValueBatch *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__value_batch__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__value_batch__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__ValueBatch *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__value_batch__descriptor);
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__query_error__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
 void   surrealdb__protocol__rpc__v1__root_user_credentials__init
@@ -2347,51 +1087,6 @@ void   surrealdb__protocol__rpc__v1__access_method__free_unpacked
   assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__access_method__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   surrealdb__protocol__rpc__v1__live_response__init
-                     (Surrealdb__Protocol__Rpc__V1__LiveResponse         *message)
-{
-  static const Surrealdb__Protocol__Rpc__V1__LiveResponse init_value = SURREALDB__PROTOCOL__RPC__V1__LIVE_RESPONSE__INIT;
-  *message = init_value;
-}
-size_t surrealdb__protocol__rpc__v1__live_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__LiveResponse *message)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__live_response__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t surrealdb__protocol__rpc__v1__live_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__LiveResponse *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__live_response__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t surrealdb__protocol__rpc__v1__live_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__LiveResponse *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__live_response__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Surrealdb__Protocol__Rpc__V1__LiveResponse *
-       surrealdb__protocol__rpc__v1__live_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Surrealdb__Protocol__Rpc__V1__LiveResponse *)
-     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__live_response__descriptor,
-                                allocator, len, data);
-}
-void   surrealdb__protocol__rpc__v1__live_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__LiveResponse *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__live_response__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
 void   surrealdb__protocol__rpc__v1__variables__variables_entry__init
                      (Surrealdb__Protocol__Rpc__V1__Variables__VariablesEntry         *message)
 {
@@ -2535,151 +1230,6 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__version_response_
   (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__version_response__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-#define surrealdb__protocol__rpc__v1__info_request__field_descriptors NULL
-#define surrealdb__protocol__rpc__v1__info_request__field_indices_by_name NULL
-#define surrealdb__protocol__rpc__v1__info_request__number_ranges NULL
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__info_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.InfoRequest",
-  "InfoRequest",
-  "Surrealdb__Protocol__Rpc__V1__InfoRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__InfoRequest),
-  0,
-  surrealdb__protocol__rpc__v1__info_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__info_request__field_indices_by_name,
-  0,  surrealdb__protocol__rpc__v1__info_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__info_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__info_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InfoResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__info_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__info_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__info_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.InfoResponse",
-  "InfoResponse",
-  "Surrealdb__Protocol__Rpc__V1__InfoResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__InfoResponse),
-  1,
-  surrealdb__protocol__rpc__v1__info_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__info_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__info_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__info_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__use_request__field_descriptors[2] =
-{
-  {
-    "namespace",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_STRING,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UseRequest, namespace_),
-    NULL,
-    &protobuf_c_empty_string,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "database",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_STRING,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UseRequest, database),
-    NULL,
-    &protobuf_c_empty_string,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__use_request__field_indices_by_name[] = {
-  1,   /* field[1] = database */
-  0,   /* field[0] = namespace */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__use_request__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 2 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__use_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.UseRequest",
-  "UseRequest",
-  "Surrealdb__Protocol__Rpc__V1__UseRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__UseRequest),
-  2,
-  surrealdb__protocol__rpc__v1__use_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__use_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__use_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__use_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__use_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UseResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__use_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__use_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__use_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.UseResponse",
-  "UseResponse",
-  "Surrealdb__Protocol__Rpc__V1__UseResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__UseResponse),
-  1,
-  surrealdb__protocol__rpc__v1__use_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__use_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__use_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__use_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
 static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__signup_request__field_descriptors[4] =
 {
   {
@@ -2760,20 +1310,20 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__signup_request__d
 static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__signup_response__field_descriptors[1] =
 {
   {
-    "values",
+    "value",
     1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SignupResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
+    offsetof(Surrealdb__Protocol__Rpc__V1__SignupResponse, value),
+    &surrealdb__protocol__v1__value__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
 static const unsigned surrealdb__protocol__rpc__v1__signup_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
+  0,   /* field[0] = value */
 };
 static const ProtobufCIntRange surrealdb__protocol__rpc__v1__signup_response__number_ranges[1 + 1] =
 {
@@ -2836,20 +1386,20 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__signin_request__d
 static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__signin_response__field_descriptors[1] =
 {
   {
-    "values",
+    "value",
     1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SigninResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
+    offsetof(Surrealdb__Protocol__Rpc__V1__SigninResponse, value),
+    &surrealdb__protocol__v1__value__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
 static const unsigned surrealdb__protocol__rpc__v1__signin_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
+  0,   /* field[0] = value */
 };
 static const ProtobufCIntRange surrealdb__protocol__rpc__v1__signin_response__number_ranges[1 + 1] =
 {
@@ -2912,20 +1462,20 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__authenticate_requ
 static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__authenticate_response__field_descriptors[1] =
 {
   {
-    "values",
+    "value",
     1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__AuthenticateResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
+    offsetof(Surrealdb__Protocol__Rpc__V1__AuthenticateResponse, value),
+    &surrealdb__protocol__v1__value__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
 static const unsigned surrealdb__protocol__rpc__v1__authenticate_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
+  0,   /* field[0] = value */
 };
 static const ProtobufCIntRange surrealdb__protocol__rpc__v1__authenticate_response__number_ranges[1 + 1] =
 {
@@ -2947,1723 +1497,170 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__authenticate_resp
   (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__authenticate_response__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-#define surrealdb__protocol__rpc__v1__invalidate_request__field_descriptors NULL
-#define surrealdb__protocol__rpc__v1__invalidate_request__field_indices_by_name NULL
-#define surrealdb__protocol__rpc__v1__invalidate_request__number_ranges NULL
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__invalidate_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.InvalidateRequest",
-  "InvalidateRequest",
-  "Surrealdb__Protocol__Rpc__V1__InvalidateRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__InvalidateRequest),
-  0,
-  surrealdb__protocol__rpc__v1__invalidate_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__invalidate_request__field_indices_by_name,
-  0,  surrealdb__protocol__rpc__v1__invalidate_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__invalidate_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__invalidate_response__field_descriptors[1] =
+static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__subscribe_request__field_descriptors[2] =
 {
   {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InvalidateResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__invalidate_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__invalidate_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__invalidate_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.InvalidateResponse",
-  "InvalidateResponse",
-  "Surrealdb__Protocol__Rpc__V1__InvalidateResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__InvalidateResponse),
-  1,
-  surrealdb__protocol__rpc__v1__invalidate_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__invalidate_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__invalidate_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__invalidate_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-#define surrealdb__protocol__rpc__v1__reset_request__field_descriptors NULL
-#define surrealdb__protocol__rpc__v1__reset_request__field_indices_by_name NULL
-#define surrealdb__protocol__rpc__v1__reset_request__number_ranges NULL
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__reset_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.ResetRequest",
-  "ResetRequest",
-  "Surrealdb__Protocol__Rpc__V1__ResetRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__ResetRequest),
-  0,
-  surrealdb__protocol__rpc__v1__reset_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__reset_request__field_indices_by_name,
-  0,  surrealdb__protocol__rpc__v1__reset_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__reset_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__reset_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__ResetResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__reset_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__reset_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__reset_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.ResetResponse",
-  "ResetResponse",
-  "Surrealdb__Protocol__Rpc__V1__ResetResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__ResetResponse),
-  1,
-  surrealdb__protocol__rpc__v1__reset_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__reset_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__reset_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__reset_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__kill_request__field_descriptors[1] =
-{
-  {
-    "live_id",
+    "query",
     1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_STRING,
     0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__KillRequest, live_id),
+    offsetof(Surrealdb__Protocol__Rpc__V1__SubscribeRequest, query),
     NULL,
     &protobuf_c_empty_string,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
-};
-static const unsigned surrealdb__protocol__rpc__v1__kill_request__field_indices_by_name[] = {
-  0,   /* field[0] = live_id */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__kill_request__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__kill_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.KillRequest",
-  "KillRequest",
-  "Surrealdb__Protocol__Rpc__V1__KillRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__KillRequest),
-  1,
-  surrealdb__protocol__rpc__v1__kill_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__kill_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__kill_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__kill_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__kill_response__field_descriptors[1] =
-{
   {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__KillResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__kill_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__kill_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__kill_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.KillResponse",
-  "KillResponse",
-  "Surrealdb__Protocol__Rpc__V1__KillResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__KillResponse),
-  1,
-  surrealdb__protocol__rpc__v1__kill_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__kill_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__kill_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__kill_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__live_request__field_descriptors[3] =
-{
-  {
-    "what",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__LiveRequest, what),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "expr",
+    "variables",
     2,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__LiveRequest, expr),
-    &surrealdb__protocol__v1__fields__descriptor,
+    offsetof(Surrealdb__Protocol__Rpc__V1__SubscribeRequest, variables),
+    &surrealdb__protocol__rpc__v1__variables__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned surrealdb__protocol__rpc__v1__subscribe_request__field_indices_by_name[] = {
+  0,   /* field[0] = query */
+  1,   /* field[1] = variables */
+};
+static const ProtobufCIntRange surrealdb__protocol__rpc__v1__subscribe_request__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__subscribe_request__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "surrealdb.protocol.rpc.v1.SubscribeRequest",
+  "SubscribeRequest",
+  "Surrealdb__Protocol__Rpc__V1__SubscribeRequest",
+  "surrealdb.protocol.rpc.v1",
+  sizeof(Surrealdb__Protocol__Rpc__V1__SubscribeRequest),
+  2,
+  surrealdb__protocol__rpc__v1__subscribe_request__field_descriptors,
+  surrealdb__protocol__rpc__v1__subscribe_request__field_indices_by_name,
+  1,  surrealdb__protocol__rpc__v1__subscribe_request__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__subscribe_request__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__subscribe_response__field_descriptors[1] =
+{
+  {
+    "notification",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__SubscribeResponse, notification),
+    &surrealdb__protocol__rpc__v1__notification__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned surrealdb__protocol__rpc__v1__subscribe_response__field_indices_by_name[] = {
+  0,   /* field[0] = notification */
+};
+static const ProtobufCIntRange surrealdb__protocol__rpc__v1__subscribe_response__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__subscribe_response__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "surrealdb.protocol.rpc.v1.SubscribeResponse",
+  "SubscribeResponse",
+  "Surrealdb__Protocol__Rpc__V1__SubscribeResponse",
+  "surrealdb.protocol.rpc.v1",
+  sizeof(Surrealdb__Protocol__Rpc__V1__SubscribeResponse),
+  1,
+  surrealdb__protocol__rpc__v1__subscribe_response__field_descriptors,
+  surrealdb__protocol__rpc__v1__subscribe_response__field_indices_by_name,
+  1,  surrealdb__protocol__rpc__v1__subscribe_response__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__subscribe_response__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__notification__field_descriptors[4] =
+{
+  {
+    "live_query_id",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__Notification, live_query_id),
+    &surrealdb__protocol__v1__uuid__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "cond",
+    "action",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__Notification, action),
+    &surrealdb__protocol__rpc__v1__action__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "record_id",
     3,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__LiveRequest, cond),
-    &surrealdb__protocol__v1__value__descriptor,
+    offsetof(Surrealdb__Protocol__Rpc__V1__Notification, record_id),
+    &surrealdb__protocol__v1__record_id__descriptor,
     NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__live_request__field_indices_by_name[] = {
-  2,   /* field[2] = cond */
-  1,   /* field[1] = expr */
-  0,   /* field[0] = what */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__live_request__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 3 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__live_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.LiveRequest",
-  "LiveRequest",
-  "Surrealdb__Protocol__Rpc__V1__LiveRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__LiveRequest),
-  3,
-  surrealdb__protocol__rpc__v1__live_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__live_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__live_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__live_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__set_request__field_descriptors[2] =
-{
-  {
-    "key",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_STRING,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SetRequest, key),
-    NULL,
-    &protobuf_c_empty_string,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
     "value",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SetRequest, value),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__set_request__field_indices_by_name[] = {
-  0,   /* field[0] = key */
-  1,   /* field[1] = value */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__set_request__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 2 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__set_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.SetRequest",
-  "SetRequest",
-  "Surrealdb__Protocol__Rpc__V1__SetRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__SetRequest),
-  2,
-  surrealdb__protocol__rpc__v1__set_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__set_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__set_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__set_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__set_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SetResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__set_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__set_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__set_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.SetResponse",
-  "SetResponse",
-  "Surrealdb__Protocol__Rpc__V1__SetResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__SetResponse),
-  1,
-  surrealdb__protocol__rpc__v1__set_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__set_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__set_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__set_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__unset_request__field_descriptors[1] =
-{
-  {
-    "key",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_STRING,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UnsetRequest, key),
-    NULL,
-    &protobuf_c_empty_string,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__unset_request__field_indices_by_name[] = {
-  0,   /* field[0] = key */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__unset_request__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__unset_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.UnsetRequest",
-  "UnsetRequest",
-  "Surrealdb__Protocol__Rpc__V1__UnsetRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__UnsetRequest),
-  1,
-  surrealdb__protocol__rpc__v1__unset_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__unset_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__unset_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__unset_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__unset_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UnsetResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__unset_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__unset_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__unset_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.UnsetResponse",
-  "UnsetResponse",
-  "Surrealdb__Protocol__Rpc__V1__UnsetResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__UnsetResponse),
-  1,
-  surrealdb__protocol__rpc__v1__unset_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__unset_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__unset_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__unset_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__create_request__field_descriptors[9] =
-{
-  {
-    "txn",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateRequest, txn),
-    &surrealdb__protocol__v1__uuid__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "only",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateRequest, only),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "what",
-    3,
-    PROTOBUF_C_LABEL_REPEATED,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateRequest, n_what),
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateRequest, what),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "data",
     4,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateRequest, data),
-    &surrealdb__protocol__v1__data__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "output",
-    5,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateRequest, output),
-    &surrealdb__protocol__v1__output__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "timeout",
-    6,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateRequest, timeout),
-    &google__protobuf__duration__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "parallel",
-    7,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateRequest, parallel),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "version",
-    8,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateRequest, version),
+    offsetof(Surrealdb__Protocol__Rpc__V1__Notification, value),
     &surrealdb__protocol__v1__value__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
-  {
-    "variables",
-    9,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateRequest, variables),
-    &surrealdb__protocol__rpc__v1__variables__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
 };
-static const unsigned surrealdb__protocol__rpc__v1__create_request__field_indices_by_name[] = {
-  3,   /* field[3] = data */
-  1,   /* field[1] = only */
-  4,   /* field[4] = output */
-  6,   /* field[6] = parallel */
-  5,   /* field[5] = timeout */
-  0,   /* field[0] = txn */
-  8,   /* field[8] = variables */
-  7,   /* field[7] = version */
-  2,   /* field[2] = what */
+static const unsigned surrealdb__protocol__rpc__v1__notification__field_indices_by_name[] = {
+  1,   /* field[1] = action */
+  0,   /* field[0] = live_query_id */
+  2,   /* field[2] = record_id */
+  3,   /* field[3] = value */
 };
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__create_request__number_ranges[1 + 1] =
+static const ProtobufCIntRange surrealdb__protocol__rpc__v1__notification__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 9 }
+  { 0, 4 }
 };
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__create_request__descriptor =
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__notification__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.CreateRequest",
-  "CreateRequest",
-  "Surrealdb__Protocol__Rpc__V1__CreateRequest",
+  "surrealdb.protocol.rpc.v1.Notification",
+  "Notification",
+  "Surrealdb__Protocol__Rpc__V1__Notification",
   "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__CreateRequest),
-  9,
-  surrealdb__protocol__rpc__v1__create_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__create_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__create_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__create_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__create_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__CreateResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__create_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__create_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__create_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.CreateResponse",
-  "CreateResponse",
-  "Surrealdb__Protocol__Rpc__V1__CreateResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__CreateResponse),
-  1,
-  surrealdb__protocol__rpc__v1__create_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__create_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__create_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__create_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__select_request__field_descriptors[19] =
-{
-  {
-    "txn",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, txn),
-    &surrealdb__protocol__v1__uuid__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "expr",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, expr),
-    &surrealdb__protocol__v1__fields__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "omit",
-    3,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, omit),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "only",
-    4,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, only),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "what",
-    5,
-    PROTOBUF_C_LABEL_REPEATED,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, n_what),
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, what),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "with",
-    6,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, with),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "cond",
-    7,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, cond),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "split",
-    8,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, split),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "group",
-    9,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, group),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "order",
-    10,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, order),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "start",
-    11,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_INT64,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, start),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "limit",
-    12,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_INT64,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, limit),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "fetch",
-    13,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, fetch),
-    &surrealdb__protocol__v1__fetchs__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "version",
-    14,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, version),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "timeout",
-    15,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, timeout),
-    &google__protobuf__duration__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "parallel",
-    16,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, parallel),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "explain",
-    17,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, explain),
-    &surrealdb__protocol__v1__explain__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "tempfiles",
-    18,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, tempfiles),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "variables",
-    19,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectRequest, variables),
-    &surrealdb__protocol__rpc__v1__variables__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__select_request__field_indices_by_name[] = {
-  6,   /* field[6] = cond */
-  16,   /* field[16] = explain */
-  1,   /* field[1] = expr */
-  12,   /* field[12] = fetch */
-  8,   /* field[8] = group */
-  11,   /* field[11] = limit */
-  2,   /* field[2] = omit */
-  3,   /* field[3] = only */
-  9,   /* field[9] = order */
-  15,   /* field[15] = parallel */
-  7,   /* field[7] = split */
-  10,   /* field[10] = start */
-  17,   /* field[17] = tempfiles */
-  14,   /* field[14] = timeout */
-  0,   /* field[0] = txn */
-  18,   /* field[18] = variables */
-  13,   /* field[13] = version */
-  4,   /* field[4] = what */
-  5,   /* field[5] = with */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__select_request__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 19 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__select_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.SelectRequest",
-  "SelectRequest",
-  "Surrealdb__Protocol__Rpc__V1__SelectRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__SelectRequest),
-  19,
-  surrealdb__protocol__rpc__v1__select_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__select_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__select_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__select_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__select_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__SelectResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__select_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__select_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__select_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.SelectResponse",
-  "SelectResponse",
-  "Surrealdb__Protocol__Rpc__V1__SelectResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__SelectResponse),
-  1,
-  surrealdb__protocol__rpc__v1__select_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__select_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__select_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__select_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__insert_request__field_descriptors[11] =
-{
-  {
-    "txn",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, txn),
-    &surrealdb__protocol__v1__uuid__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "into",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, into),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "data",
-    3,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, data),
-    &surrealdb__protocol__v1__data__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "ignore",
-    4,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, ignore),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "update",
-    5,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, update),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "output",
-    6,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, output),
-    &surrealdb__protocol__v1__output__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "timeout",
-    7,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, timeout),
-    &google__protobuf__duration__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "parallel",
-    8,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, parallel),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "relation",
-    9,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, relation),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "version",
-    10,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, version),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "variables",
-    11,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertRequest, variables),
-    &surrealdb__protocol__rpc__v1__variables__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__insert_request__field_indices_by_name[] = {
-  2,   /* field[2] = data */
-  3,   /* field[3] = ignore */
-  1,   /* field[1] = into */
-  5,   /* field[5] = output */
-  7,   /* field[7] = parallel */
-  8,   /* field[8] = relation */
-  6,   /* field[6] = timeout */
-  0,   /* field[0] = txn */
-  4,   /* field[4] = update */
-  10,   /* field[10] = variables */
-  9,   /* field[9] = version */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__insert_request__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 11 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__insert_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.InsertRequest",
-  "InsertRequest",
-  "Surrealdb__Protocol__Rpc__V1__InsertRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__InsertRequest),
-  11,
-  surrealdb__protocol__rpc__v1__insert_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__insert_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__insert_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__insert_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__insert_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__InsertResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__insert_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__insert_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__insert_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.InsertResponse",
-  "InsertResponse",
-  "Surrealdb__Protocol__Rpc__V1__InsertResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__InsertResponse),
-  1,
-  surrealdb__protocol__rpc__v1__insert_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__insert_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__insert_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__insert_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__upsert_request__field_descriptors[11] =
-{
-  {
-    "txn",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, txn),
-    &surrealdb__protocol__v1__uuid__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "only",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, only),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "what",
-    3,
-    PROTOBUF_C_LABEL_REPEATED,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, n_what),
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, what),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "with",
-    4,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, with),
-    &surrealdb__protocol__v1__with__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "data",
-    5,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, data),
-    &surrealdb__protocol__v1__data__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "cond",
-    6,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, cond),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "output",
-    7,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, output),
-    &surrealdb__protocol__v1__output__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "timeout",
-    8,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, timeout),
-    &google__protobuf__duration__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "parallel",
-    9,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, parallel),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "explain",
-    10,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, explain),
-    &surrealdb__protocol__v1__explain__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "variables",
-    11,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertRequest, variables),
-    &surrealdb__protocol__rpc__v1__variables__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__upsert_request__field_indices_by_name[] = {
-  5,   /* field[5] = cond */
-  4,   /* field[4] = data */
-  9,   /* field[9] = explain */
-  1,   /* field[1] = only */
-  6,   /* field[6] = output */
-  8,   /* field[8] = parallel */
-  7,   /* field[7] = timeout */
-  0,   /* field[0] = txn */
-  10,   /* field[10] = variables */
-  2,   /* field[2] = what */
-  3,   /* field[3] = with */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__upsert_request__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 11 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__upsert_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.UpsertRequest",
-  "UpsertRequest",
-  "Surrealdb__Protocol__Rpc__V1__UpsertRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__UpsertRequest),
-  11,
-  surrealdb__protocol__rpc__v1__upsert_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__upsert_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__upsert_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__upsert_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__upsert_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpsertResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__upsert_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__upsert_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__upsert_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.UpsertResponse",
-  "UpsertResponse",
-  "Surrealdb__Protocol__Rpc__V1__UpsertResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__UpsertResponse),
-  1,
-  surrealdb__protocol__rpc__v1__upsert_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__upsert_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__upsert_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__upsert_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__update_request__field_descriptors[11] =
-{
-  {
-    "txn",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, txn),
-    &surrealdb__protocol__v1__uuid__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "only",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, only),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "what",
-    3,
-    PROTOBUF_C_LABEL_REPEATED,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, n_what),
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, what),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "with",
-    4,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, with),
-    &surrealdb__protocol__v1__with__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "data",
-    5,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, data),
-    &surrealdb__protocol__v1__data__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "cond",
-    6,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, cond),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "output",
-    7,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, output),
-    &surrealdb__protocol__v1__output__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "timeout",
-    9,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, timeout),
-    &google__protobuf__duration__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "parallel",
-    10,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, parallel),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "explain",
-    11,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, explain),
-    &surrealdb__protocol__v1__explain__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "variables",
-    12,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateRequest, variables),
-    &surrealdb__protocol__rpc__v1__variables__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__update_request__field_indices_by_name[] = {
-  5,   /* field[5] = cond */
-  4,   /* field[4] = data */
-  9,   /* field[9] = explain */
-  1,   /* field[1] = only */
-  6,   /* field[6] = output */
-  8,   /* field[8] = parallel */
-  7,   /* field[7] = timeout */
-  0,   /* field[0] = txn */
-  10,   /* field[10] = variables */
-  2,   /* field[2] = what */
-  3,   /* field[3] = with */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__update_request__number_ranges[2 + 1] =
-{
-  { 1, 0 },
-  { 9, 7 },
-  { 0, 11 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__update_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.UpdateRequest",
-  "UpdateRequest",
-  "Surrealdb__Protocol__Rpc__V1__UpdateRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__UpdateRequest),
-  11,
-  surrealdb__protocol__rpc__v1__update_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__update_request__field_indices_by_name,
-  2,  surrealdb__protocol__rpc__v1__update_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__update_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__update_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__UpdateResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__update_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__update_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__update_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.UpdateResponse",
-  "UpdateResponse",
-  "Surrealdb__Protocol__Rpc__V1__UpdateResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__UpdateResponse),
-  1,
-  surrealdb__protocol__rpc__v1__update_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__update_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__update_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__update_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__delete_request__field_descriptors[10] =
-{
-  {
-    "txn",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, txn),
-    &surrealdb__protocol__v1__uuid__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "only",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, only),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "what",
-    3,
-    PROTOBUF_C_LABEL_REPEATED,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, n_what),
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, what),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "with",
-    4,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, with),
-    &surrealdb__protocol__v1__with__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "cond",
-    5,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, cond),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "output",
-    6,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, output),
-    &surrealdb__protocol__v1__output__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "timeout",
-    7,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, timeout),
-    &google__protobuf__duration__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "parallel",
-    8,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, parallel),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "explain",
-    9,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, explain),
-    &surrealdb__protocol__v1__explain__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "variables",
-    10,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteRequest, variables),
-    &surrealdb__protocol__rpc__v1__variables__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__delete_request__field_indices_by_name[] = {
-  4,   /* field[4] = cond */
-  8,   /* field[8] = explain */
-  1,   /* field[1] = only */
-  5,   /* field[5] = output */
-  7,   /* field[7] = parallel */
-  6,   /* field[6] = timeout */
-  0,   /* field[0] = txn */
-  9,   /* field[9] = variables */
-  2,   /* field[2] = what */
-  3,   /* field[3] = with */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__delete_request__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 10 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__delete_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.DeleteRequest",
-  "DeleteRequest",
-  "Surrealdb__Protocol__Rpc__V1__DeleteRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__DeleteRequest),
-  10,
-  surrealdb__protocol__rpc__v1__delete_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__delete_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__delete_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__delete_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__delete_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__DeleteResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__delete_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__delete_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__delete_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.DeleteResponse",
-  "DeleteResponse",
-  "Surrealdb__Protocol__Rpc__V1__DeleteResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__DeleteResponse),
-  1,
-  surrealdb__protocol__rpc__v1__delete_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__delete_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__delete_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__delete_response__init,
+  sizeof(Surrealdb__Protocol__Rpc__V1__Notification),
+  4,
+  surrealdb__protocol__rpc__v1__notification__field_descriptors,
+  surrealdb__protocol__rpc__v1__notification__field_indices_by_name,
+  1,  surrealdb__protocol__rpc__v1__notification__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__notification__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
 static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_request__field_descriptors[2] =
@@ -4717,7 +1714,7 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__query_request__de
   (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__query_request__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_response__field_descriptors[4] =
+static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_response__field_descriptors[5] =
 {
   {
     "query_index",
@@ -4756,13 +1753,25 @@ static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_respon
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "values",
+    "error",
     4,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__QueryResponse, error),
+    &surrealdb__protocol__rpc__v1__query_error__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "values",
+    5,
+    PROTOBUF_C_LABEL_REPEATED,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(Surrealdb__Protocol__Rpc__V1__QueryResponse, n_values),
     offsetof(Surrealdb__Protocol__Rpc__V1__QueryResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
+    &surrealdb__protocol__v1__value__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
@@ -4770,14 +1779,15 @@ static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_respon
 };
 static const unsigned surrealdb__protocol__rpc__v1__query_response__field_indices_by_name[] = {
   1,   /* field[1] = batch_index */
+  3,   /* field[3] = error */
   0,   /* field[0] = query_index */
   2,   /* field[2] = stats */
-  3,   /* field[3] = values */
+  4,   /* field[4] = values */
 };
 static const ProtobufCIntRange surrealdb__protocol__rpc__v1__query_response__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 4 }
+  { 0, 5 }
 };
 const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__query_response__descriptor =
 {
@@ -4787,22 +1797,58 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__query_response__d
   "Surrealdb__Protocol__Rpc__V1__QueryResponse",
   "surrealdb.protocol.rpc.v1",
   sizeof(Surrealdb__Protocol__Rpc__V1__QueryResponse),
-  4,
+  5,
   surrealdb__protocol__rpc__v1__query_response__field_descriptors,
   surrealdb__protocol__rpc__v1__query_response__field_indices_by_name,
   1,  surrealdb__protocol__rpc__v1__query_response__number_ranges,
   (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__query_response__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_stats__field_descriptors[3] =
+static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_stats__field_descriptors[6] =
 {
   {
-    "num_records",
+    "records_returned",
     1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_INT64,
     0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__QueryStats, num_records),
+    offsetof(Surrealdb__Protocol__Rpc__V1__QueryStats, records_returned),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "bytes_returned",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_INT64,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__QueryStats, bytes_returned),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "records_scanned",
+    3,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_INT64,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__QueryStats, records_scanned),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "bytes_scanned",
+    4,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_INT64,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__QueryStats, bytes_scanned),
     NULL,
     NULL,
     0,             /* flags */
@@ -4810,7 +1856,7 @@ static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_stats_
   },
   {
     "start_time",
-    2,
+    5,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     0,   /* quantifier_offset */
@@ -4822,7 +1868,7 @@ static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_stats_
   },
   {
     "execution_duration",
-    3,
+    6,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     0,   /* quantifier_offset */
@@ -4834,14 +1880,17 @@ static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_stats_
   },
 };
 static const unsigned surrealdb__protocol__rpc__v1__query_stats__field_indices_by_name[] = {
-  2,   /* field[2] = execution_duration */
-  0,   /* field[0] = num_records */
-  1,   /* field[1] = start_time */
+  1,   /* field[1] = bytes_returned */
+  3,   /* field[3] = bytes_scanned */
+  5,   /* field[5] = execution_duration */
+  0,   /* field[0] = records_returned */
+  2,   /* field[2] = records_scanned */
+  4,   /* field[4] = start_time */
 };
 static const ProtobufCIntRange surrealdb__protocol__rpc__v1__query_stats__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 3 }
+  { 0, 6 }
 };
 const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__query_stats__descriptor =
 {
@@ -4851,357 +1900,62 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__query_stats__desc
   "Surrealdb__Protocol__Rpc__V1__QueryStats",
   "surrealdb.protocol.rpc.v1",
   sizeof(Surrealdb__Protocol__Rpc__V1__QueryStats),
-  3,
+  6,
   surrealdb__protocol__rpc__v1__query_stats__field_descriptors,
   surrealdb__protocol__rpc__v1__query_stats__field_indices_by_name,
   1,  surrealdb__protocol__rpc__v1__query_stats__number_ranges,
   (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__query_stats__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__relate_request__field_descriptors[11] =
+static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__query_error__field_descriptors[2] =
 {
   {
-    "txn",
+    "code",
     1,
     PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
+    PROTOBUF_C_TYPE_INT64,
     0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, txn),
-    &surrealdb__protocol__v1__uuid__descriptor,
+    offsetof(Surrealdb__Protocol__Rpc__V1__QueryError, code),
+    NULL,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "only",
+    "message",
     2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, only),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "kind",
-    3,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, kind),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "from",
-    4,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, from),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "with",
-    5,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, with),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "uniq",
-    6,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, uniq),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "data",
-    7,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, data),
-    &surrealdb__protocol__v1__data__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "output",
-    8,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, output),
-    &surrealdb__protocol__v1__output__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "timeout",
-    9,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, timeout),
-    &google__protobuf__duration__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "parallel",
-    10,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_BOOL,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, parallel),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "variables",
-    11,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateRequest, variables),
-    &surrealdb__protocol__rpc__v1__variables__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__relate_request__field_indices_by_name[] = {
-  6,   /* field[6] = data */
-  3,   /* field[3] = from */
-  2,   /* field[2] = kind */
-  1,   /* field[1] = only */
-  7,   /* field[7] = output */
-  9,   /* field[9] = parallel */
-  8,   /* field[8] = timeout */
-  0,   /* field[0] = txn */
-  5,   /* field[5] = uniq */
-  10,   /* field[10] = variables */
-  4,   /* field[4] = with */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__relate_request__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 11 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__relate_request__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.RelateRequest",
-  "RelateRequest",
-  "Surrealdb__Protocol__Rpc__V1__RelateRequest",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__RelateRequest),
-  11,
-  surrealdb__protocol__rpc__v1__relate_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__relate_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__relate_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__relate_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__relate_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RelateResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__relate_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__relate_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__relate_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.RelateResponse",
-  "RelateResponse",
-  "Surrealdb__Protocol__Rpc__V1__RelateResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__RelateResponse),
-  1,
-  surrealdb__protocol__rpc__v1__relate_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__relate_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__relate_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__relate_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__run_function_request__field_descriptors[3] =
-{
-  {
-    "name",
-    1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_STRING,
     0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RunFunctionRequest, name),
+    offsetof(Surrealdb__Protocol__Rpc__V1__QueryError, message),
     NULL,
     &protobuf_c_empty_string,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
-  {
-    "version",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_STRING,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RunFunctionRequest, version),
-    NULL,
-    &protobuf_c_empty_string,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "args",
-    3,
-    PROTOBUF_C_LABEL_REPEATED,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(Surrealdb__Protocol__Rpc__V1__RunFunctionRequest, n_args),
-    offsetof(Surrealdb__Protocol__Rpc__V1__RunFunctionRequest, args),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
 };
-static const unsigned surrealdb__protocol__rpc__v1__run_function_request__field_indices_by_name[] = {
-  2,   /* field[2] = args */
-  0,   /* field[0] = name */
-  1,   /* field[1] = version */
+static const unsigned surrealdb__protocol__rpc__v1__query_error__field_indices_by_name[] = {
+  0,   /* field[0] = code */
+  1,   /* field[1] = message */
 };
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__run_function_request__number_ranges[1 + 1] =
+static const ProtobufCIntRange surrealdb__protocol__rpc__v1__query_error__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 3 }
+  { 0, 2 }
 };
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__run_function_request__descriptor =
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__query_error__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.RunFunctionRequest",
-  "RunFunctionRequest",
-  "Surrealdb__Protocol__Rpc__V1__RunFunctionRequest",
+  "surrealdb.protocol.rpc.v1.QueryError",
+  "QueryError",
+  "Surrealdb__Protocol__Rpc__V1__QueryError",
   "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__RunFunctionRequest),
-  3,
-  surrealdb__protocol__rpc__v1__run_function_request__field_descriptors,
-  surrealdb__protocol__rpc__v1__run_function_request__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__run_function_request__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__run_function_request__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__run_function_response__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__RunFunctionResponse, values),
-    &surrealdb__protocol__rpc__v1__value_batch__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__run_function_response__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__run_function_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__run_function_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.RunFunctionResponse",
-  "RunFunctionResponse",
-  "Surrealdb__Protocol__Rpc__V1__RunFunctionResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__RunFunctionResponse),
-  1,
-  surrealdb__protocol__rpc__v1__run_function_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__run_function_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__run_function_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__run_function_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__value_batch__field_descriptors[1] =
-{
-  {
-    "values",
-    1,
-    PROTOBUF_C_LABEL_REPEATED,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(Surrealdb__Protocol__Rpc__V1__ValueBatch, n_values),
-    offsetof(Surrealdb__Protocol__Rpc__V1__ValueBatch, values),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__value_batch__field_indices_by_name[] = {
-  0,   /* field[0] = values */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__value_batch__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__value_batch__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.ValueBatch",
-  "ValueBatch",
-  "Surrealdb__Protocol__Rpc__V1__ValueBatch",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__ValueBatch),
-  1,
-  surrealdb__protocol__rpc__v1__value_batch__field_descriptors,
-  surrealdb__protocol__rpc__v1__value_batch__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__value_batch__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__value_batch__init,
+  sizeof(Surrealdb__Protocol__Rpc__V1__QueryError),
+  2,
+  surrealdb__protocol__rpc__v1__query_error__field_descriptors,
+  surrealdb__protocol__rpc__v1__query_error__field_indices_by_name,
+  1,  surrealdb__protocol__rpc__v1__query_error__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__query_error__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
 static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__root_user_credentials__field_descriptors[2] =
@@ -5691,83 +2445,6 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__access_method__de
   (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__access_method__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__live_response__field_descriptors[4] =
-{
-  {
-    "id",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__LiveResponse, id),
-    &surrealdb__protocol__v1__uuid__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "action",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__LiveResponse, action),
-    &surrealdb__protocol__rpc__v1__action__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "record",
-    3,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__LiveResponse, record),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "result",
-    4,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    0,   /* quantifier_offset */
-    offsetof(Surrealdb__Protocol__Rpc__V1__LiveResponse, result),
-    &surrealdb__protocol__v1__value__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned surrealdb__protocol__rpc__v1__live_response__field_indices_by_name[] = {
-  1,   /* field[1] = action */
-  0,   /* field[0] = id */
-  2,   /* field[2] = record */
-  3,   /* field[3] = result */
-};
-static const ProtobufCIntRange surrealdb__protocol__rpc__v1__live_response__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 4 }
-};
-const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__live_response__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "surrealdb.protocol.rpc.v1.LiveResponse",
-  "LiveResponse",
-  "Surrealdb__Protocol__Rpc__V1__LiveResponse",
-  "surrealdb.protocol.rpc.v1",
-  sizeof(Surrealdb__Protocol__Rpc__V1__LiveResponse),
-  4,
-  surrealdb__protocol__rpc__v1__live_response__field_descriptors,
-  surrealdb__protocol__rpc__v1__live_response__field_indices_by_name,
-  1,  surrealdb__protocol__rpc__v1__live_response__number_ranges,
-  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__live_response__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
 static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__variables__variables_entry__field_descriptors[2] =
 {
   {
@@ -5860,9 +2537,9 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__variables__descri
 static const ProtobufCEnumValue surrealdb__protocol__rpc__v1__action__enum_values_by_number[5] =
 {
   { "ACTION_UNSPECIFIED", "SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_UNSPECIFIED", 0 },
-  { "ACTION_CREATE", "SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_CREATE", 1 },
-  { "ACTION_UPDATE", "SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_UPDATE", 2 },
-  { "ACTION_DELETE", "SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_DELETE", 3 },
+  { "ACTION_CREATED", "SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_CREATED", 1 },
+  { "ACTION_UPDATED", "SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_UPDATED", 2 },
+  { "ACTION_DELETED", "SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_DELETED", 3 },
   { "ACTION_KILLED", "SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_KILLED", 4 },
 };
 static const ProtobufCIntRange surrealdb__protocol__rpc__v1__action__value_ranges[] = {
@@ -5870,11 +2547,11 @@ static const ProtobufCIntRange surrealdb__protocol__rpc__v1__action__value_range
 };
 static const ProtobufCEnumValueIndex surrealdb__protocol__rpc__v1__action__enum_values_by_name[5] =
 {
-  { "ACTION_CREATE", 1 },
-  { "ACTION_DELETE", 3 },
+  { "ACTION_CREATED", 1 },
+  { "ACTION_DELETED", 3 },
   { "ACTION_KILLED", 4 },
   { "ACTION_UNSPECIFIED", 0 },
-  { "ACTION_UPDATE", 2 },
+  { "ACTION_UPDATED", 2 },
 };
 const ProtobufCEnumDescriptor surrealdb__protocol__rpc__v1__action__descriptor =
 {
@@ -5891,53 +2568,23 @@ const ProtobufCEnumDescriptor surrealdb__protocol__rpc__v1__action__descriptor =
   surrealdb__protocol__rpc__v1__action__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCMethodDescriptor surrealdb__protocol__rpc__v1__surreal_dbservice__method_descriptors[22] =
+static const ProtobufCMethodDescriptor surrealdb__protocol__rpc__v1__surreal_dbservice__method_descriptors[7] =
 {
   { "Health", &surrealdb__protocol__rpc__v1__health_request__descriptor, &surrealdb__protocol__rpc__v1__health_response__descriptor },
   { "Version", &surrealdb__protocol__rpc__v1__version_request__descriptor, &surrealdb__protocol__rpc__v1__version_response__descriptor },
-  { "Info", &surrealdb__protocol__rpc__v1__info_request__descriptor, &surrealdb__protocol__rpc__v1__info_response__descriptor },
-  { "Query", &surrealdb__protocol__rpc__v1__query_request__descriptor, &surrealdb__protocol__rpc__v1__query_response__descriptor },
-  { "Live", &surrealdb__protocol__rpc__v1__live_request__descriptor, &surrealdb__protocol__rpc__v1__live_response__descriptor },
-  { "Use", &surrealdb__protocol__rpc__v1__use_request__descriptor, &surrealdb__protocol__rpc__v1__use_response__descriptor },
   { "Signup", &surrealdb__protocol__rpc__v1__signup_request__descriptor, &surrealdb__protocol__rpc__v1__signup_response__descriptor },
   { "Signin", &surrealdb__protocol__rpc__v1__signin_request__descriptor, &surrealdb__protocol__rpc__v1__signin_response__descriptor },
   { "Authenticate", &surrealdb__protocol__rpc__v1__authenticate_request__descriptor, &surrealdb__protocol__rpc__v1__authenticate_response__descriptor },
-  { "Invalidate", &surrealdb__protocol__rpc__v1__invalidate_request__descriptor, &surrealdb__protocol__rpc__v1__invalidate_response__descriptor },
-  { "Reset", &surrealdb__protocol__rpc__v1__reset_request__descriptor, &surrealdb__protocol__rpc__v1__reset_response__descriptor },
-  { "Kill", &surrealdb__protocol__rpc__v1__kill_request__descriptor, &surrealdb__protocol__rpc__v1__kill_response__descriptor },
-  { "Set", &surrealdb__protocol__rpc__v1__set_request__descriptor, &surrealdb__protocol__rpc__v1__set_response__descriptor },
-  { "Unset", &surrealdb__protocol__rpc__v1__unset_request__descriptor, &surrealdb__protocol__rpc__v1__unset_response__descriptor },
-  { "Select", &surrealdb__protocol__rpc__v1__select_request__descriptor, &surrealdb__protocol__rpc__v1__select_response__descriptor },
-  { "Create", &surrealdb__protocol__rpc__v1__create_request__descriptor, &surrealdb__protocol__rpc__v1__create_response__descriptor },
-  { "Insert", &surrealdb__protocol__rpc__v1__insert_request__descriptor, &surrealdb__protocol__rpc__v1__insert_response__descriptor },
-  { "Upsert", &surrealdb__protocol__rpc__v1__upsert_request__descriptor, &surrealdb__protocol__rpc__v1__upsert_response__descriptor },
-  { "Update", &surrealdb__protocol__rpc__v1__update_request__descriptor, &surrealdb__protocol__rpc__v1__update_response__descriptor },
-  { "Delete", &surrealdb__protocol__rpc__v1__delete_request__descriptor, &surrealdb__protocol__rpc__v1__delete_response__descriptor },
-  { "Relate", &surrealdb__protocol__rpc__v1__relate_request__descriptor, &surrealdb__protocol__rpc__v1__relate_response__descriptor },
-  { "RunFunction", &surrealdb__protocol__rpc__v1__run_function_request__descriptor, &surrealdb__protocol__rpc__v1__run_function_response__descriptor },
+  { "Query", &surrealdb__protocol__rpc__v1__query_request__descriptor, &surrealdb__protocol__rpc__v1__query_response__descriptor },
+  { "Subscribe", &surrealdb__protocol__rpc__v1__subscribe_request__descriptor, &surrealdb__protocol__rpc__v1__subscribe_response__descriptor },
 };
 const unsigned surrealdb__protocol__rpc__v1__surreal_dbservice__method_indices_by_name[] = {
-  8,        /* Authenticate */
-  15,        /* Create */
-  19,        /* Delete */
+  4,        /* Authenticate */
   0,        /* Health */
-  2,        /* Info */
-  16,        /* Insert */
-  9,        /* Invalidate */
-  11,        /* Kill */
-  4,        /* Live */
-  3,        /* Query */
-  20,        /* Relate */
-  10,        /* Reset */
-  21,        /* RunFunction */
-  14,        /* Select */
-  12,        /* Set */
-  7,        /* Signin */
-  6,        /* Signup */
-  13,        /* Unset */
-  18,        /* Update */
-  17,        /* Upsert */
-  5,        /* Use */
+  5,        /* Query */
+  3,        /* Signin */
+  2,        /* Signup */
+  6,        /* Subscribe */
   1         /* Version */
 };
 const ProtobufCServiceDescriptor surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor =
@@ -5947,7 +2594,7 @@ const ProtobufCServiceDescriptor surrealdb__protocol__rpc__v1__surreal_dbservice
   "SurrealDBService",
   "Surrealdb__Protocol__Rpc__V1__SurrealDBService",
   "surrealdb.protocol.rpc.v1",
-  22,
+  7,
   surrealdb__protocol__rpc__v1__surreal_dbservice__method_descriptors,
   surrealdb__protocol__rpc__v1__surreal_dbservice__method_indices_by_name
 };
@@ -5967,45 +2614,13 @@ void surrealdb__protocol__rpc__v1__surreal_dbservice__version(ProtobufCService *
   assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
   service->invoke(service, 1, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
-void surrealdb__protocol__rpc__v1__surreal_dbservice__info(ProtobufCService *service,
-                                                           const Surrealdb__Protocol__Rpc__V1__InfoRequest *input,
-                                                           Surrealdb__Protocol__Rpc__V1__InfoResponse_Closure closure,
-                                                           void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 2, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__query(ProtobufCService *service,
-                                                            const Surrealdb__Protocol__Rpc__V1__QueryRequest *input,
-                                                            Surrealdb__Protocol__Rpc__V1__QueryResponse_Closure closure,
-                                                            void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 3, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__live(ProtobufCService *service,
-                                                           const Surrealdb__Protocol__Rpc__V1__LiveRequest *input,
-                                                           Surrealdb__Protocol__Rpc__V1__LiveResponse_Closure closure,
-                                                           void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 4, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__use(ProtobufCService *service,
-                                                          const Surrealdb__Protocol__Rpc__V1__UseRequest *input,
-                                                          Surrealdb__Protocol__Rpc__V1__UseResponse_Closure closure,
-                                                          void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 5, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
 void surrealdb__protocol__rpc__v1__surreal_dbservice__signup(ProtobufCService *service,
                                                              const Surrealdb__Protocol__Rpc__V1__SignupRequest *input,
                                                              Surrealdb__Protocol__Rpc__V1__SignupResponse_Closure closure,
                                                              void *closure_data)
 {
   assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 6, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+  service->invoke(service, 2, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
 void surrealdb__protocol__rpc__v1__surreal_dbservice__signin(ProtobufCService *service,
                                                              const Surrealdb__Protocol__Rpc__V1__SigninRequest *input,
@@ -6013,7 +2628,7 @@ void surrealdb__protocol__rpc__v1__surreal_dbservice__signin(ProtobufCService *s
                                                              void *closure_data)
 {
   assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 7, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+  service->invoke(service, 3, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
 void surrealdb__protocol__rpc__v1__surreal_dbservice__authenticate(ProtobufCService *service,
                                                                    const Surrealdb__Protocol__Rpc__V1__AuthenticateRequest *input,
@@ -6021,111 +2636,23 @@ void surrealdb__protocol__rpc__v1__surreal_dbservice__authenticate(ProtobufCServ
                                                                    void *closure_data)
 {
   assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 8, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+  service->invoke(service, 4, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
-void surrealdb__protocol__rpc__v1__surreal_dbservice__invalidate(ProtobufCService *service,
-                                                                 const Surrealdb__Protocol__Rpc__V1__InvalidateRequest *input,
-                                                                 Surrealdb__Protocol__Rpc__V1__InvalidateResponse_Closure closure,
-                                                                 void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 9, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__reset(ProtobufCService *service,
-                                                            const Surrealdb__Protocol__Rpc__V1__ResetRequest *input,
-                                                            Surrealdb__Protocol__Rpc__V1__ResetResponse_Closure closure,
+void surrealdb__protocol__rpc__v1__surreal_dbservice__query(ProtobufCService *service,
+                                                            const Surrealdb__Protocol__Rpc__V1__QueryRequest *input,
+                                                            Surrealdb__Protocol__Rpc__V1__QueryResponse_Closure closure,
                                                             void *closure_data)
 {
   assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 10, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+  service->invoke(service, 5, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
-void surrealdb__protocol__rpc__v1__surreal_dbservice__kill(ProtobufCService *service,
-                                                           const Surrealdb__Protocol__Rpc__V1__KillRequest *input,
-                                                           Surrealdb__Protocol__Rpc__V1__KillResponse_Closure closure,
-                                                           void *closure_data)
+void surrealdb__protocol__rpc__v1__surreal_dbservice__subscribe(ProtobufCService *service,
+                                                                const Surrealdb__Protocol__Rpc__V1__SubscribeRequest *input,
+                                                                Surrealdb__Protocol__Rpc__V1__SubscribeResponse_Closure closure,
+                                                                void *closure_data)
 {
   assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 11, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__set(ProtobufCService *service,
-                                                          const Surrealdb__Protocol__Rpc__V1__SetRequest *input,
-                                                          Surrealdb__Protocol__Rpc__V1__SetResponse_Closure closure,
-                                                          void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 12, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__unset(ProtobufCService *service,
-                                                            const Surrealdb__Protocol__Rpc__V1__UnsetRequest *input,
-                                                            Surrealdb__Protocol__Rpc__V1__UnsetResponse_Closure closure,
-                                                            void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 13, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__select(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__SelectRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__SelectResponse_Closure closure,
-                                                             void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 14, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__create(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__CreateRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__CreateResponse_Closure closure,
-                                                             void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 15, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__insert(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__InsertRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__InsertResponse_Closure closure,
-                                                             void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 16, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__upsert(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__UpsertRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__UpsertResponse_Closure closure,
-                                                             void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 17, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__update(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__UpdateRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__UpdateResponse_Closure closure,
-                                                             void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 18, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__delete(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__DeleteRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__DeleteResponse_Closure closure,
-                                                             void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 19, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__relate(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__RelateRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__RelateResponse_Closure closure,
-                                                             void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 20, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
-}
-void surrealdb__protocol__rpc__v1__surreal_dbservice__run_function(ProtobufCService *service,
-                                                                   const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *input,
-                                                                   Surrealdb__Protocol__Rpc__V1__RunFunctionResponse_Closure closure,
-                                                                   void *closure_data)
-{
-  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 21, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+  service->invoke(service, 6, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
 void surrealdb__protocol__rpc__v1__surreal_dbservice__init (Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
                                                             Surrealdb__Protocol__Rpc__V1__SurrealDBService_ServiceDestroy destroy)

--- a/gen/c/surrealdb/protocol/rpc/v1/rpc.pb-c.h
+++ b/gen/c/surrealdb/protocol/rpc/v1/rpc.pb-c.h
@@ -15,7 +15,6 @@ PROTOBUF_C__BEGIN_DECLS
 #endif
 
 #include "surrealdb/protocol/v1/value.pb-c.h"
-#include "surrealdb/protocol/v1/expr.pb-c.h"
 #include "google/protobuf/duration.pb-c.h"
 #include "google/protobuf/timestamp.pb-c.h"
 
@@ -23,47 +22,19 @@ typedef struct Surrealdb__Protocol__Rpc__V1__HealthRequest Surrealdb__Protocol__
 typedef struct Surrealdb__Protocol__Rpc__V1__HealthResponse Surrealdb__Protocol__Rpc__V1__HealthResponse;
 typedef struct Surrealdb__Protocol__Rpc__V1__VersionRequest Surrealdb__Protocol__Rpc__V1__VersionRequest;
 typedef struct Surrealdb__Protocol__Rpc__V1__VersionResponse Surrealdb__Protocol__Rpc__V1__VersionResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__InfoRequest Surrealdb__Protocol__Rpc__V1__InfoRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__InfoResponse Surrealdb__Protocol__Rpc__V1__InfoResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__UseRequest Surrealdb__Protocol__Rpc__V1__UseRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__UseResponse Surrealdb__Protocol__Rpc__V1__UseResponse;
 typedef struct Surrealdb__Protocol__Rpc__V1__SignupRequest Surrealdb__Protocol__Rpc__V1__SignupRequest;
 typedef struct Surrealdb__Protocol__Rpc__V1__SignupResponse Surrealdb__Protocol__Rpc__V1__SignupResponse;
 typedef struct Surrealdb__Protocol__Rpc__V1__SigninRequest Surrealdb__Protocol__Rpc__V1__SigninRequest;
 typedef struct Surrealdb__Protocol__Rpc__V1__SigninResponse Surrealdb__Protocol__Rpc__V1__SigninResponse;
 typedef struct Surrealdb__Protocol__Rpc__V1__AuthenticateRequest Surrealdb__Protocol__Rpc__V1__AuthenticateRequest;
 typedef struct Surrealdb__Protocol__Rpc__V1__AuthenticateResponse Surrealdb__Protocol__Rpc__V1__AuthenticateResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__InvalidateRequest Surrealdb__Protocol__Rpc__V1__InvalidateRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__InvalidateResponse Surrealdb__Protocol__Rpc__V1__InvalidateResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__ResetRequest Surrealdb__Protocol__Rpc__V1__ResetRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__ResetResponse Surrealdb__Protocol__Rpc__V1__ResetResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__KillRequest Surrealdb__Protocol__Rpc__V1__KillRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__KillResponse Surrealdb__Protocol__Rpc__V1__KillResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__LiveRequest Surrealdb__Protocol__Rpc__V1__LiveRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__SetRequest Surrealdb__Protocol__Rpc__V1__SetRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__SetResponse Surrealdb__Protocol__Rpc__V1__SetResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__UnsetRequest Surrealdb__Protocol__Rpc__V1__UnsetRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__UnsetResponse Surrealdb__Protocol__Rpc__V1__UnsetResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__CreateRequest Surrealdb__Protocol__Rpc__V1__CreateRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__CreateResponse Surrealdb__Protocol__Rpc__V1__CreateResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__SelectRequest Surrealdb__Protocol__Rpc__V1__SelectRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__SelectResponse Surrealdb__Protocol__Rpc__V1__SelectResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__InsertRequest Surrealdb__Protocol__Rpc__V1__InsertRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__InsertResponse Surrealdb__Protocol__Rpc__V1__InsertResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__UpsertRequest Surrealdb__Protocol__Rpc__V1__UpsertRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__UpsertResponse Surrealdb__Protocol__Rpc__V1__UpsertResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__UpdateRequest Surrealdb__Protocol__Rpc__V1__UpdateRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__UpdateResponse Surrealdb__Protocol__Rpc__V1__UpdateResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__DeleteRequest Surrealdb__Protocol__Rpc__V1__DeleteRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__DeleteResponse Surrealdb__Protocol__Rpc__V1__DeleteResponse;
+typedef struct Surrealdb__Protocol__Rpc__V1__SubscribeRequest Surrealdb__Protocol__Rpc__V1__SubscribeRequest;
+typedef struct Surrealdb__Protocol__Rpc__V1__SubscribeResponse Surrealdb__Protocol__Rpc__V1__SubscribeResponse;
+typedef struct Surrealdb__Protocol__Rpc__V1__Notification Surrealdb__Protocol__Rpc__V1__Notification;
 typedef struct Surrealdb__Protocol__Rpc__V1__QueryRequest Surrealdb__Protocol__Rpc__V1__QueryRequest;
 typedef struct Surrealdb__Protocol__Rpc__V1__QueryResponse Surrealdb__Protocol__Rpc__V1__QueryResponse;
 typedef struct Surrealdb__Protocol__Rpc__V1__QueryStats Surrealdb__Protocol__Rpc__V1__QueryStats;
-typedef struct Surrealdb__Protocol__Rpc__V1__RelateRequest Surrealdb__Protocol__Rpc__V1__RelateRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__RelateResponse Surrealdb__Protocol__Rpc__V1__RelateResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__RunFunctionRequest Surrealdb__Protocol__Rpc__V1__RunFunctionRequest;
-typedef struct Surrealdb__Protocol__Rpc__V1__RunFunctionResponse Surrealdb__Protocol__Rpc__V1__RunFunctionResponse;
-typedef struct Surrealdb__Protocol__Rpc__V1__ValueBatch Surrealdb__Protocol__Rpc__V1__ValueBatch;
+typedef struct Surrealdb__Protocol__Rpc__V1__QueryError Surrealdb__Protocol__Rpc__V1__QueryError;
 typedef struct Surrealdb__Protocol__Rpc__V1__RootUserCredentials Surrealdb__Protocol__Rpc__V1__RootUserCredentials;
 typedef struct Surrealdb__Protocol__Rpc__V1__NamespaceAccessCredentials Surrealdb__Protocol__Rpc__V1__NamespaceAccessCredentials;
 typedef struct Surrealdb__Protocol__Rpc__V1__DatabaseAccessCredentials Surrealdb__Protocol__Rpc__V1__DatabaseAccessCredentials;
@@ -71,7 +42,6 @@ typedef struct Surrealdb__Protocol__Rpc__V1__NamespaceUserCredentials Surrealdb_
 typedef struct Surrealdb__Protocol__Rpc__V1__DatabaseUserCredentials Surrealdb__Protocol__Rpc__V1__DatabaseUserCredentials;
 typedef struct Surrealdb__Protocol__Rpc__V1__AccessToken Surrealdb__Protocol__Rpc__V1__AccessToken;
 typedef struct Surrealdb__Protocol__Rpc__V1__AccessMethod Surrealdb__Protocol__Rpc__V1__AccessMethod;
-typedef struct Surrealdb__Protocol__Rpc__V1__LiveResponse Surrealdb__Protocol__Rpc__V1__LiveResponse;
 typedef struct Surrealdb__Protocol__Rpc__V1__Variables Surrealdb__Protocol__Rpc__V1__Variables;
 typedef struct Surrealdb__Protocol__Rpc__V1__Variables__VariablesEntry Surrealdb__Protocol__Rpc__V1__Variables__VariablesEntry;
 
@@ -83,9 +53,9 @@ typedef struct Surrealdb__Protocol__Rpc__V1__Variables__VariablesEntry Surrealdb
  */
 typedef enum _Surrealdb__Protocol__Rpc__V1__Action {
   SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_UNSPECIFIED = 0,
-  SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_CREATE = 1,
-  SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_UPDATE = 2,
-  SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_DELETE = 3,
+  SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_CREATED = 1,
+  SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_UPDATED = 2,
+  SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_DELETED = 3,
   SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_KILLED = 4
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(SURREALDB__PROTOCOL__RPC__V1__ACTION)
 } Surrealdb__Protocol__Rpc__V1__Action;
@@ -142,58 +112,6 @@ struct  Surrealdb__Protocol__Rpc__V1__VersionResponse
 
 
 /*
- * Request to get information about the database.
- */
-struct  Surrealdb__Protocol__Rpc__V1__InfoRequest
-{
-  ProtobufCMessage base;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__INFO_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__info_request__descriptor) \
- }
-
-
-/*
- * Response to an info request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__InfoResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__INFO_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__info_response__descriptor) \
-, NULL }
-
-
-/*
- * Request to change the current namespace and database.
- */
-struct  Surrealdb__Protocol__Rpc__V1__UseRequest
-{
-  ProtobufCMessage base;
-  char *namespace_;
-  char *database;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__USE_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__use_request__descriptor) \
-, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
-
-
-/*
- * Response to a use request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__UseResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__USE_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__use_response__descriptor) \
-, NULL }
-
-
-/*
  * Request to sign up a new user.
  */
 struct  Surrealdb__Protocol__Rpc__V1__SignupRequest
@@ -215,7 +133,7 @@ struct  Surrealdb__Protocol__Rpc__V1__SignupRequest
 struct  Surrealdb__Protocol__Rpc__V1__SignupResponse
 {
   ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
+  Surrealdb__Protocol__V1__Value *value;
 };
 #define SURREALDB__PROTOCOL__RPC__V1__SIGNUP_RESPONSE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__signup_response__descriptor) \
@@ -241,7 +159,7 @@ struct  Surrealdb__Protocol__Rpc__V1__SigninRequest
 struct  Surrealdb__Protocol__Rpc__V1__SigninResponse
 {
   ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
+  Surrealdb__Protocol__V1__Value *value;
 };
 #define SURREALDB__PROTOCOL__RPC__V1__SIGNIN_RESPONSE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__signin_response__descriptor) \
@@ -267,7 +185,7 @@ struct  Surrealdb__Protocol__Rpc__V1__AuthenticateRequest
 struct  Surrealdb__Protocol__Rpc__V1__AuthenticateResponse
 {
   ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
+  Surrealdb__Protocol__V1__Value *value;
 };
 #define SURREALDB__PROTOCOL__RPC__V1__AUTHENTICATE_RESPONSE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__authenticate_response__descriptor) \
@@ -275,373 +193,46 @@ struct  Surrealdb__Protocol__Rpc__V1__AuthenticateResponse
 
 
 /*
- * Request to invalidate a user.
- */
-struct  Surrealdb__Protocol__Rpc__V1__InvalidateRequest
-{
-  ProtobufCMessage base;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__INVALIDATE_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__invalidate_request__descriptor) \
- }
-
-
-/*
- * Response to an invalidate request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__InvalidateResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__INVALIDATE_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__invalidate_response__descriptor) \
-, NULL }
-
-
-/*
- * Request to reset the database.
- */
-struct  Surrealdb__Protocol__Rpc__V1__ResetRequest
-{
-  ProtobufCMessage base;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__RESET_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__reset_request__descriptor) \
- }
-
-
-/*
- * Response to a reset request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__ResetResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__RESET_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__reset_response__descriptor) \
-, NULL }
-
-
-/*
- * Request to kill a live query.
- */
-struct  Surrealdb__Protocol__Rpc__V1__KillRequest
-{
-  ProtobufCMessage base;
-  char *live_id;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__KILL_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__kill_request__descriptor) \
-, (char *)protobuf_c_empty_string }
-
-
-/*
- * Response to a kill request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__KillResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__KILL_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__kill_response__descriptor) \
-, NULL }
-
-
-/*
  * Request to issue a live query.
  */
-struct  Surrealdb__Protocol__Rpc__V1__LiveRequest
+struct  Surrealdb__Protocol__Rpc__V1__SubscribeRequest
 {
   ProtobufCMessage base;
-  Surrealdb__Protocol__V1__Value *what;
-  Surrealdb__Protocol__V1__Fields *expr;
-  Surrealdb__Protocol__V1__Value *cond;
+  char *query;
+  Surrealdb__Protocol__Rpc__V1__Variables *variables;
 };
-#define SURREALDB__PROTOCOL__RPC__V1__LIVE_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__live_request__descriptor) \
-, NULL, NULL, NULL }
-
-
-/*
- * Request to set a value.
- */
-struct  Surrealdb__Protocol__Rpc__V1__SetRequest
-{
-  ProtobufCMessage base;
-  char *key;
-  Surrealdb__Protocol__V1__Value *value;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__SET_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__set_request__descriptor) \
+#define SURREALDB__PROTOCOL__RPC__V1__SUBSCRIBE_REQUEST__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__subscribe_request__descriptor) \
 , (char *)protobuf_c_empty_string, NULL }
 
 
 /*
- * Response to a set request.
+ * Response to a live query.
  */
-struct  Surrealdb__Protocol__Rpc__V1__SetResponse
+struct  Surrealdb__Protocol__Rpc__V1__SubscribeResponse
 {
   ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
+  Surrealdb__Protocol__Rpc__V1__Notification *notification;
 };
-#define SURREALDB__PROTOCOL__RPC__V1__SET_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__set_response__descriptor) \
+#define SURREALDB__PROTOCOL__RPC__V1__SUBSCRIBE_RESPONSE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__subscribe_response__descriptor) \
 , NULL }
 
 
 /*
- * Request to unset a value.
+ * A notification from a live query.
  */
-struct  Surrealdb__Protocol__Rpc__V1__UnsetRequest
+struct  Surrealdb__Protocol__Rpc__V1__Notification
 {
   ProtobufCMessage base;
-  char *key;
+  Surrealdb__Protocol__V1__Uuid *live_query_id;
+  Surrealdb__Protocol__Rpc__V1__Action action;
+  Surrealdb__Protocol__V1__RecordId *record_id;
+  Surrealdb__Protocol__V1__Value *value;
 };
-#define SURREALDB__PROTOCOL__RPC__V1__UNSET_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__unset_request__descriptor) \
-, (char *)protobuf_c_empty_string }
-
-
-/*
- * Response to an unset request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__UnsetResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__UNSET_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__unset_response__descriptor) \
-, NULL }
-
-
-/*
- * Request to create a new record.
- */
-struct  Surrealdb__Protocol__Rpc__V1__CreateRequest
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__V1__Uuid *txn;
-  protobuf_c_boolean only;
-  size_t n_what;
-  Surrealdb__Protocol__V1__Value **what;
-  Surrealdb__Protocol__V1__Data *data;
-  Surrealdb__Protocol__V1__Output *output;
-  Google__Protobuf__Duration *timeout;
-  protobuf_c_boolean parallel;
-  Surrealdb__Protocol__V1__Value *version;
-  Surrealdb__Protocol__Rpc__V1__Variables *variables;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__CREATE_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__create_request__descriptor) \
-, NULL, 0, 0,NULL, NULL, NULL, NULL, 0, NULL, NULL }
-
-
-/*
- * Response to a create request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__CreateResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__CREATE_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__create_response__descriptor) \
-, NULL }
-
-
-/*
- * Request to select values from the database.
- */
-struct  Surrealdb__Protocol__Rpc__V1__SelectRequest
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__V1__Uuid *txn;
-  Surrealdb__Protocol__V1__Fields *expr;
-  Surrealdb__Protocol__V1__Value *omit;
-  protobuf_c_boolean only;
-  size_t n_what;
-  Surrealdb__Protocol__V1__Value **what;
-  Surrealdb__Protocol__V1__Value *with;
-  Surrealdb__Protocol__V1__Value *cond;
-  Surrealdb__Protocol__V1__Value *split;
-  Surrealdb__Protocol__V1__Value *group;
-  Surrealdb__Protocol__V1__Value *order;
-  int64_t start;
-  int64_t limit;
-  Surrealdb__Protocol__V1__Fetchs *fetch;
-  Surrealdb__Protocol__V1__Value *version;
-  Google__Protobuf__Duration *timeout;
-  protobuf_c_boolean parallel;
-  Surrealdb__Protocol__V1__Explain *explain;
-  protobuf_c_boolean tempfiles;
-  Surrealdb__Protocol__Rpc__V1__Variables *variables;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__SELECT_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__select_request__descriptor) \
-, NULL, NULL, NULL, 0, 0,NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, NULL, NULL, NULL, 0, NULL, 0, NULL }
-
-
-/*
- * Response to a select request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__SelectResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__SELECT_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__select_response__descriptor) \
-, NULL }
-
-
-/*
- * Request to insert a new record.
- */
-struct  Surrealdb__Protocol__Rpc__V1__InsertRequest
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__V1__Uuid *txn;
-  Surrealdb__Protocol__V1__Value *into;
-  Surrealdb__Protocol__V1__Data *data;
-  protobuf_c_boolean ignore;
-  Surrealdb__Protocol__V1__Value *update;
-  Surrealdb__Protocol__V1__Output *output;
-  Google__Protobuf__Duration *timeout;
-  protobuf_c_boolean parallel;
-  protobuf_c_boolean relation;
-  Surrealdb__Protocol__V1__Value *version;
-  Surrealdb__Protocol__Rpc__V1__Variables *variables;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__INSERT_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__insert_request__descriptor) \
-, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0, 0, NULL, NULL }
-
-
-/*
- * Response to an insert request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__InsertResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__INSERT_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__insert_response__descriptor) \
-, NULL }
-
-
-/*
- * Request to upsert a record.
- */
-struct  Surrealdb__Protocol__Rpc__V1__UpsertRequest
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__V1__Uuid *txn;
-  protobuf_c_boolean only;
-  size_t n_what;
-  Surrealdb__Protocol__V1__Value **what;
-  Surrealdb__Protocol__V1__With *with;
-  Surrealdb__Protocol__V1__Data *data;
-  Surrealdb__Protocol__V1__Value *cond;
-  Surrealdb__Protocol__V1__Output *output;
-  Google__Protobuf__Duration *timeout;
-  protobuf_c_boolean parallel;
-  Surrealdb__Protocol__V1__Explain *explain;
-  Surrealdb__Protocol__Rpc__V1__Variables *variables;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__UPSERT_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__upsert_request__descriptor) \
-, NULL, 0, 0,NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL }
-
-
-/*
- * Response to an upsert request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__UpsertResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__UPSERT_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__upsert_response__descriptor) \
-, NULL }
-
-
-/*
- * Request to update a record.
- */
-struct  Surrealdb__Protocol__Rpc__V1__UpdateRequest
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__V1__Uuid *txn;
-  protobuf_c_boolean only;
-  size_t n_what;
-  Surrealdb__Protocol__V1__Value **what;
-  Surrealdb__Protocol__V1__With *with;
-  Surrealdb__Protocol__V1__Data *data;
-  Surrealdb__Protocol__V1__Value *cond;
-  Surrealdb__Protocol__V1__Output *output;
-  Google__Protobuf__Duration *timeout;
-  protobuf_c_boolean parallel;
-  Surrealdb__Protocol__V1__Explain *explain;
-  Surrealdb__Protocol__Rpc__V1__Variables *variables;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__UPDATE_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__update_request__descriptor) \
-, NULL, 0, 0,NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL }
-
-
-/*
- * Response to an update request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__UpdateResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__UPDATE_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__update_response__descriptor) \
-, NULL }
-
-
-/*
- * Request to delete a record.
- */
-struct  Surrealdb__Protocol__Rpc__V1__DeleteRequest
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__V1__Uuid *txn;
-  protobuf_c_boolean only;
-  size_t n_what;
-  Surrealdb__Protocol__V1__Value **what;
-  Surrealdb__Protocol__V1__With *with;
-  Surrealdb__Protocol__V1__Value *cond;
-  Surrealdb__Protocol__V1__Output *output;
-  Google__Protobuf__Duration *timeout;
-  protobuf_c_boolean parallel;
-  Surrealdb__Protocol__V1__Explain *explain;
-  Surrealdb__Protocol__Rpc__V1__Variables *variables;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__DELETE_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__delete_request__descriptor) \
-, NULL, 0, 0,NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL }
-
-
-/*
- * Response to a delete request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__DeleteResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__DELETE_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__delete_response__descriptor) \
-, NULL }
+#define SURREALDB__PROTOCOL__RPC__V1__NOTIFICATION__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__notification__descriptor) \
+, NULL, SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_UNSPECIFIED, NULL, NULL }
 
 
 /*
@@ -666,14 +257,14 @@ struct  Surrealdb__Protocol__Rpc__V1__QueryRequest
  * value batches may elide the stats.
  * 
  * Responses are ordered by query index, then batch index. For example:
- *  QueryResponse(query_index=0, batch_index=0)
- *  QueryResponse(query_index=0, batch_index=1)
- *  QueryResponse(query_index=1, batch_index=0)
- *  QueryResponse(query_index=2, batch_index=0)
- *  QueryResponse(query_index=2, batch_index=1)
- *  QueryResponse(query_index=2, batch_index=2)
- *  QueryResponse(query_index=3, batch_index=0)
- *  QueryResponse(query_index=4, batch_index=0)
+ *  QueryResponse(query_index=0, batch_index=0, stats=None)
+ *  QueryResponse(query_index=0, batch_index=1, stats=Some(..))
+ *  QueryResponse(query_index=1, batch_index=0, stats=Some(..))
+ *  QueryResponse(query_index=2, batch_index=0, stats=None)
+ *  QueryResponse(query_index=2, batch_index=1, stats=None)
+ *  QueryResponse(query_index=2, batch_index=2, stats=Some(..))
+ *  QueryResponse(query_index=3, batch_index=0, stats=Some(..))
+ *  QueryResponse(query_index=4, batch_index=0, stats=Some(..))
  */
 struct  Surrealdb__Protocol__Rpc__V1__QueryResponse
 {
@@ -688,16 +279,22 @@ struct  Surrealdb__Protocol__Rpc__V1__QueryResponse
   uint64_t batch_index;
   /*
    * The query stats.
+   * This is only expected to be present in the last batch of each query.
    */
   Surrealdb__Protocol__Rpc__V1__QueryStats *stats;
   /*
-   * The value batch.
+   * The error, if any.
    */
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
+  Surrealdb__Protocol__Rpc__V1__QueryError *error;
+  /*
+   * A batch of values.
+   */
+  size_t n_values;
+  Surrealdb__Protocol__V1__Value **values;
 };
 #define SURREALDB__PROTOCOL__RPC__V1__QUERY_RESPONSE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__query_response__descriptor) \
-, 0, 0, NULL, NULL }
+, 0, 0, NULL, NULL, 0,NULL }
 
 
 /*
@@ -709,7 +306,19 @@ struct  Surrealdb__Protocol__Rpc__V1__QueryStats
   /*
    * The number of records returned. -1 if unknown.
    */
-  int64_t num_records;
+  int64_t records_returned;
+  /*
+   * The number of bytes returned. -1 if unknown.
+   */
+  int64_t bytes_returned;
+  /*
+   * The number of records scanned. -1 if unknown.
+   */
+  int64_t records_scanned;
+  /*
+   * The number of bytes scanned. -1 if unknown.
+   */
+  int64_t bytes_scanned;
   /*
    * The start time of the query.
    */
@@ -721,86 +330,27 @@ struct  Surrealdb__Protocol__Rpc__V1__QueryStats
 };
 #define SURREALDB__PROTOCOL__RPC__V1__QUERY_STATS__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__query_stats__descriptor) \
-, 0, NULL, NULL }
+, 0, 0, 0, 0, NULL, NULL }
 
 
 /*
- * Request to relate two records.
+ * Query error.
  */
-struct  Surrealdb__Protocol__Rpc__V1__RelateRequest
+struct  Surrealdb__Protocol__Rpc__V1__QueryError
 {
   ProtobufCMessage base;
-  Surrealdb__Protocol__V1__Uuid *txn;
-  protobuf_c_boolean only;
-  Surrealdb__Protocol__V1__Value *kind;
-  Surrealdb__Protocol__V1__Value *from;
-  Surrealdb__Protocol__V1__Value *with;
-  protobuf_c_boolean uniq;
-  Surrealdb__Protocol__V1__Data *data;
-  Surrealdb__Protocol__V1__Output *output;
-  Google__Protobuf__Duration *timeout;
-  protobuf_c_boolean parallel;
-  Surrealdb__Protocol__Rpc__V1__Variables *variables;
+  /*
+   * The error code.
+   */
+  int64_t code;
+  /*
+   * The error message.
+   */
+  char *message;
 };
-#define SURREALDB__PROTOCOL__RPC__V1__RELATE_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__relate_request__descriptor) \
-, NULL, 0, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0, NULL }
-
-
-/*
- * Response to a relate request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__RelateResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__RELATE_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__relate_response__descriptor) \
-, NULL }
-
-
-/*
- * Request to run a function.
- */
-struct  Surrealdb__Protocol__Rpc__V1__RunFunctionRequest
-{
-  ProtobufCMessage base;
-  char *name;
-  char *version;
-  size_t n_args;
-  Surrealdb__Protocol__V1__Value **args;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__RUN_FUNCTION_REQUEST__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__run_function_request__descriptor) \
-, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string, 0,NULL }
-
-
-/*
- * Response to a run function request.
- */
-struct  Surrealdb__Protocol__Rpc__V1__RunFunctionResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__Rpc__V1__ValueBatch *values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__RUN_FUNCTION_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__run_function_response__descriptor) \
-, NULL }
-
-
-/*
- * Batch of values.
- */
-struct  Surrealdb__Protocol__Rpc__V1__ValueBatch
-{
-  ProtobufCMessage base;
-  size_t n_values;
-  Surrealdb__Protocol__V1__Value **values;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__VALUE_BATCH__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__value_batch__descriptor) \
-, 0,NULL }
+#define SURREALDB__PROTOCOL__RPC__V1__QUERY_ERROR__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__query_error__descriptor) \
+, 0, (char *)protobuf_c_empty_string }
 
 
 /*
@@ -925,22 +475,6 @@ struct  Surrealdb__Protocol__Rpc__V1__AccessMethod
 , SURREALDB__PROTOCOL__RPC__V1__ACCESS_METHOD__METHOD__NOT_SET, {0} }
 
 
-/*
- * Response to a live query.
- */
-struct  Surrealdb__Protocol__Rpc__V1__LiveResponse
-{
-  ProtobufCMessage base;
-  Surrealdb__Protocol__V1__Uuid *id;
-  Surrealdb__Protocol__Rpc__V1__Action action;
-  Surrealdb__Protocol__V1__Value *record;
-  Surrealdb__Protocol__V1__Value *result;
-};
-#define SURREALDB__PROTOCOL__RPC__V1__LIVE_RESPONSE__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__live_response__descriptor) \
-, NULL, SURREALDB__PROTOCOL__RPC__V1__ACTION__ACTION_UNSPECIFIED, NULL, NULL }
-
-
 struct  Surrealdb__Protocol__Rpc__V1__Variables__VariablesEntry
 {
   ProtobufCMessage base;
@@ -1041,82 +575,6 @@ Surrealdb__Protocol__Rpc__V1__VersionResponse *
                       const uint8_t       *data);
 void   surrealdb__protocol__rpc__v1__version_response__free_unpacked
                      (Surrealdb__Protocol__Rpc__V1__VersionResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__InfoRequest methods */
-void   surrealdb__protocol__rpc__v1__info_request__init
-                     (Surrealdb__Protocol__Rpc__V1__InfoRequest         *message);
-size_t surrealdb__protocol__rpc__v1__info_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InfoRequest   *message);
-size_t surrealdb__protocol__rpc__v1__info_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InfoRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__info_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InfoRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__InfoRequest *
-       surrealdb__protocol__rpc__v1__info_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__info_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InfoRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__InfoResponse methods */
-void   surrealdb__protocol__rpc__v1__info_response__init
-                     (Surrealdb__Protocol__Rpc__V1__InfoResponse         *message);
-size_t surrealdb__protocol__rpc__v1__info_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InfoResponse   *message);
-size_t surrealdb__protocol__rpc__v1__info_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InfoResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__info_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InfoResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__InfoResponse *
-       surrealdb__protocol__rpc__v1__info_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__info_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InfoResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__UseRequest methods */
-void   surrealdb__protocol__rpc__v1__use_request__init
-                     (Surrealdb__Protocol__Rpc__V1__UseRequest         *message);
-size_t surrealdb__protocol__rpc__v1__use_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UseRequest   *message);
-size_t surrealdb__protocol__rpc__v1__use_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UseRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__use_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UseRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__UseRequest *
-       surrealdb__protocol__rpc__v1__use_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__use_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UseRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__UseResponse methods */
-void   surrealdb__protocol__rpc__v1__use_response__init
-                     (Surrealdb__Protocol__Rpc__V1__UseResponse         *message);
-size_t surrealdb__protocol__rpc__v1__use_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UseResponse   *message);
-size_t surrealdb__protocol__rpc__v1__use_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UseResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__use_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UseResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__UseResponse *
-       surrealdb__protocol__rpc__v1__use_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__use_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UseResponse *message,
                       ProtobufCAllocator *allocator);
 /* Surrealdb__Protocol__Rpc__V1__SignupRequest methods */
 void   surrealdb__protocol__rpc__v1__signup_request__init
@@ -1232,442 +690,62 @@ Surrealdb__Protocol__Rpc__V1__AuthenticateResponse *
 void   surrealdb__protocol__rpc__v1__authenticate_response__free_unpacked
                      (Surrealdb__Protocol__Rpc__V1__AuthenticateResponse *message,
                       ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__InvalidateRequest methods */
-void   surrealdb__protocol__rpc__v1__invalidate_request__init
-                     (Surrealdb__Protocol__Rpc__V1__InvalidateRequest         *message);
-size_t surrealdb__protocol__rpc__v1__invalidate_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateRequest   *message);
-size_t surrealdb__protocol__rpc__v1__invalidate_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateRequest   *message,
+/* Surrealdb__Protocol__Rpc__V1__SubscribeRequest methods */
+void   surrealdb__protocol__rpc__v1__subscribe_request__init
+                     (Surrealdb__Protocol__Rpc__V1__SubscribeRequest         *message);
+size_t surrealdb__protocol__rpc__v1__subscribe_request__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeRequest   *message);
+size_t surrealdb__protocol__rpc__v1__subscribe_request__pack
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeRequest   *message,
                       uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__invalidate_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateRequest   *message,
+size_t surrealdb__protocol__rpc__v1__subscribe_request__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeRequest   *message,
                       ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__InvalidateRequest *
-       surrealdb__protocol__rpc__v1__invalidate_request__unpack
+Surrealdb__Protocol__Rpc__V1__SubscribeRequest *
+       surrealdb__protocol__rpc__v1__subscribe_request__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__invalidate_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InvalidateRequest *message,
+void   surrealdb__protocol__rpc__v1__subscribe_request__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__SubscribeRequest *message,
                       ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__InvalidateResponse methods */
-void   surrealdb__protocol__rpc__v1__invalidate_response__init
-                     (Surrealdb__Protocol__Rpc__V1__InvalidateResponse         *message);
-size_t surrealdb__protocol__rpc__v1__invalidate_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateResponse   *message);
-size_t surrealdb__protocol__rpc__v1__invalidate_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateResponse   *message,
+/* Surrealdb__Protocol__Rpc__V1__SubscribeResponse methods */
+void   surrealdb__protocol__rpc__v1__subscribe_response__init
+                     (Surrealdb__Protocol__Rpc__V1__SubscribeResponse         *message);
+size_t surrealdb__protocol__rpc__v1__subscribe_response__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeResponse   *message);
+size_t surrealdb__protocol__rpc__v1__subscribe_response__pack
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeResponse   *message,
                       uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__invalidate_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InvalidateResponse   *message,
+size_t surrealdb__protocol__rpc__v1__subscribe_response__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__SubscribeResponse   *message,
                       ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__InvalidateResponse *
-       surrealdb__protocol__rpc__v1__invalidate_response__unpack
+Surrealdb__Protocol__Rpc__V1__SubscribeResponse *
+       surrealdb__protocol__rpc__v1__subscribe_response__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__invalidate_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InvalidateResponse *message,
+void   surrealdb__protocol__rpc__v1__subscribe_response__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__SubscribeResponse *message,
                       ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__ResetRequest methods */
-void   surrealdb__protocol__rpc__v1__reset_request__init
-                     (Surrealdb__Protocol__Rpc__V1__ResetRequest         *message);
-size_t surrealdb__protocol__rpc__v1__reset_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest   *message);
-size_t surrealdb__protocol__rpc__v1__reset_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest   *message,
+/* Surrealdb__Protocol__Rpc__V1__Notification methods */
+void   surrealdb__protocol__rpc__v1__notification__init
+                     (Surrealdb__Protocol__Rpc__V1__Notification         *message);
+size_t surrealdb__protocol__rpc__v1__notification__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__Notification   *message);
+size_t surrealdb__protocol__rpc__v1__notification__pack
+                     (const Surrealdb__Protocol__Rpc__V1__Notification   *message,
                       uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__reset_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest   *message,
+size_t surrealdb__protocol__rpc__v1__notification__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__Notification   *message,
                       ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__ResetRequest *
-       surrealdb__protocol__rpc__v1__reset_request__unpack
+Surrealdb__Protocol__Rpc__V1__Notification *
+       surrealdb__protocol__rpc__v1__notification__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__reset_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__ResetRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__ResetResponse methods */
-void   surrealdb__protocol__rpc__v1__reset_response__init
-                     (Surrealdb__Protocol__Rpc__V1__ResetResponse         *message);
-size_t surrealdb__protocol__rpc__v1__reset_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse   *message);
-size_t surrealdb__protocol__rpc__v1__reset_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__reset_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__ResetResponse *
-       surrealdb__protocol__rpc__v1__reset_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__reset_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__ResetResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__KillRequest methods */
-void   surrealdb__protocol__rpc__v1__kill_request__init
-                     (Surrealdb__Protocol__Rpc__V1__KillRequest         *message);
-size_t surrealdb__protocol__rpc__v1__kill_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__KillRequest   *message);
-size_t surrealdb__protocol__rpc__v1__kill_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__KillRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__kill_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__KillRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__KillRequest *
-       surrealdb__protocol__rpc__v1__kill_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__kill_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__KillRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__KillResponse methods */
-void   surrealdb__protocol__rpc__v1__kill_response__init
-                     (Surrealdb__Protocol__Rpc__V1__KillResponse         *message);
-size_t surrealdb__protocol__rpc__v1__kill_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__KillResponse   *message);
-size_t surrealdb__protocol__rpc__v1__kill_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__KillResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__kill_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__KillResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__KillResponse *
-       surrealdb__protocol__rpc__v1__kill_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__kill_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__KillResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__LiveRequest methods */
-void   surrealdb__protocol__rpc__v1__live_request__init
-                     (Surrealdb__Protocol__Rpc__V1__LiveRequest         *message);
-size_t surrealdb__protocol__rpc__v1__live_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__LiveRequest   *message);
-size_t surrealdb__protocol__rpc__v1__live_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__LiveRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__live_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__LiveRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__LiveRequest *
-       surrealdb__protocol__rpc__v1__live_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__live_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__LiveRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__SetRequest methods */
-void   surrealdb__protocol__rpc__v1__set_request__init
-                     (Surrealdb__Protocol__Rpc__V1__SetRequest         *message);
-size_t surrealdb__protocol__rpc__v1__set_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__SetRequest   *message);
-size_t surrealdb__protocol__rpc__v1__set_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__SetRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__set_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__SetRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__SetRequest *
-       surrealdb__protocol__rpc__v1__set_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__set_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__SetRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__SetResponse methods */
-void   surrealdb__protocol__rpc__v1__set_response__init
-                     (Surrealdb__Protocol__Rpc__V1__SetResponse         *message);
-size_t surrealdb__protocol__rpc__v1__set_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__SetResponse   *message);
-size_t surrealdb__protocol__rpc__v1__set_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__SetResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__set_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__SetResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__SetResponse *
-       surrealdb__protocol__rpc__v1__set_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__set_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__SetResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__UnsetRequest methods */
-void   surrealdb__protocol__rpc__v1__unset_request__init
-                     (Surrealdb__Protocol__Rpc__V1__UnsetRequest         *message);
-size_t surrealdb__protocol__rpc__v1__unset_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest   *message);
-size_t surrealdb__protocol__rpc__v1__unset_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__unset_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__UnsetRequest *
-       surrealdb__protocol__rpc__v1__unset_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__unset_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UnsetRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__UnsetResponse methods */
-void   surrealdb__protocol__rpc__v1__unset_response__init
-                     (Surrealdb__Protocol__Rpc__V1__UnsetResponse         *message);
-size_t surrealdb__protocol__rpc__v1__unset_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse   *message);
-size_t surrealdb__protocol__rpc__v1__unset_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__unset_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__UnsetResponse *
-       surrealdb__protocol__rpc__v1__unset_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__unset_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UnsetResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__CreateRequest methods */
-void   surrealdb__protocol__rpc__v1__create_request__init
-                     (Surrealdb__Protocol__Rpc__V1__CreateRequest         *message);
-size_t surrealdb__protocol__rpc__v1__create_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__CreateRequest   *message);
-size_t surrealdb__protocol__rpc__v1__create_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__CreateRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__create_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__CreateRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__CreateRequest *
-       surrealdb__protocol__rpc__v1__create_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__create_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__CreateRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__CreateResponse methods */
-void   surrealdb__protocol__rpc__v1__create_response__init
-                     (Surrealdb__Protocol__Rpc__V1__CreateResponse         *message);
-size_t surrealdb__protocol__rpc__v1__create_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__CreateResponse   *message);
-size_t surrealdb__protocol__rpc__v1__create_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__CreateResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__create_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__CreateResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__CreateResponse *
-       surrealdb__protocol__rpc__v1__create_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__create_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__CreateResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__SelectRequest methods */
-void   surrealdb__protocol__rpc__v1__select_request__init
-                     (Surrealdb__Protocol__Rpc__V1__SelectRequest         *message);
-size_t surrealdb__protocol__rpc__v1__select_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__SelectRequest   *message);
-size_t surrealdb__protocol__rpc__v1__select_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__SelectRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__select_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__SelectRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__SelectRequest *
-       surrealdb__protocol__rpc__v1__select_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__select_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__SelectRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__SelectResponse methods */
-void   surrealdb__protocol__rpc__v1__select_response__init
-                     (Surrealdb__Protocol__Rpc__V1__SelectResponse         *message);
-size_t surrealdb__protocol__rpc__v1__select_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__SelectResponse   *message);
-size_t surrealdb__protocol__rpc__v1__select_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__SelectResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__select_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__SelectResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__SelectResponse *
-       surrealdb__protocol__rpc__v1__select_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__select_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__SelectResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__InsertRequest methods */
-void   surrealdb__protocol__rpc__v1__insert_request__init
-                     (Surrealdb__Protocol__Rpc__V1__InsertRequest         *message);
-size_t surrealdb__protocol__rpc__v1__insert_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InsertRequest   *message);
-size_t surrealdb__protocol__rpc__v1__insert_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InsertRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__insert_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InsertRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__InsertRequest *
-       surrealdb__protocol__rpc__v1__insert_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__insert_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InsertRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__InsertResponse methods */
-void   surrealdb__protocol__rpc__v1__insert_response__init
-                     (Surrealdb__Protocol__Rpc__V1__InsertResponse         *message);
-size_t surrealdb__protocol__rpc__v1__insert_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__InsertResponse   *message);
-size_t surrealdb__protocol__rpc__v1__insert_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__InsertResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__insert_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__InsertResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__InsertResponse *
-       surrealdb__protocol__rpc__v1__insert_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__insert_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__InsertResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__UpsertRequest methods */
-void   surrealdb__protocol__rpc__v1__upsert_request__init
-                     (Surrealdb__Protocol__Rpc__V1__UpsertRequest         *message);
-size_t surrealdb__protocol__rpc__v1__upsert_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertRequest   *message);
-size_t surrealdb__protocol__rpc__v1__upsert_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__upsert_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__UpsertRequest *
-       surrealdb__protocol__rpc__v1__upsert_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__upsert_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UpsertRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__UpsertResponse methods */
-void   surrealdb__protocol__rpc__v1__upsert_response__init
-                     (Surrealdb__Protocol__Rpc__V1__UpsertResponse         *message);
-size_t surrealdb__protocol__rpc__v1__upsert_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertResponse   *message);
-size_t surrealdb__protocol__rpc__v1__upsert_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__upsert_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UpsertResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__UpsertResponse *
-       surrealdb__protocol__rpc__v1__upsert_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__upsert_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UpsertResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__UpdateRequest methods */
-void   surrealdb__protocol__rpc__v1__update_request__init
-                     (Surrealdb__Protocol__Rpc__V1__UpdateRequest         *message);
-size_t surrealdb__protocol__rpc__v1__update_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateRequest   *message);
-size_t surrealdb__protocol__rpc__v1__update_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__update_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__UpdateRequest *
-       surrealdb__protocol__rpc__v1__update_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__update_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UpdateRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__UpdateResponse methods */
-void   surrealdb__protocol__rpc__v1__update_response__init
-                     (Surrealdb__Protocol__Rpc__V1__UpdateResponse         *message);
-size_t surrealdb__protocol__rpc__v1__update_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateResponse   *message);
-size_t surrealdb__protocol__rpc__v1__update_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__update_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__UpdateResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__UpdateResponse *
-       surrealdb__protocol__rpc__v1__update_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__update_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__UpdateResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__DeleteRequest methods */
-void   surrealdb__protocol__rpc__v1__delete_request__init
-                     (Surrealdb__Protocol__Rpc__V1__DeleteRequest         *message);
-size_t surrealdb__protocol__rpc__v1__delete_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteRequest   *message);
-size_t surrealdb__protocol__rpc__v1__delete_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__delete_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__DeleteRequest *
-       surrealdb__protocol__rpc__v1__delete_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__delete_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__DeleteRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__DeleteResponse methods */
-void   surrealdb__protocol__rpc__v1__delete_response__init
-                     (Surrealdb__Protocol__Rpc__V1__DeleteResponse         *message);
-size_t surrealdb__protocol__rpc__v1__delete_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteResponse   *message);
-size_t surrealdb__protocol__rpc__v1__delete_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__delete_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__DeleteResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__DeleteResponse *
-       surrealdb__protocol__rpc__v1__delete_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__delete_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__DeleteResponse *message,
+void   surrealdb__protocol__rpc__v1__notification__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__Notification *message,
                       ProtobufCAllocator *allocator);
 /* Surrealdb__Protocol__Rpc__V1__QueryRequest methods */
 void   surrealdb__protocol__rpc__v1__query_request__init
@@ -1726,100 +804,24 @@ Surrealdb__Protocol__Rpc__V1__QueryStats *
 void   surrealdb__protocol__rpc__v1__query_stats__free_unpacked
                      (Surrealdb__Protocol__Rpc__V1__QueryStats *message,
                       ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__RelateRequest methods */
-void   surrealdb__protocol__rpc__v1__relate_request__init
-                     (Surrealdb__Protocol__Rpc__V1__RelateRequest         *message);
-size_t surrealdb__protocol__rpc__v1__relate_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__RelateRequest   *message);
-size_t surrealdb__protocol__rpc__v1__relate_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__RelateRequest   *message,
+/* Surrealdb__Protocol__Rpc__V1__QueryError methods */
+void   surrealdb__protocol__rpc__v1__query_error__init
+                     (Surrealdb__Protocol__Rpc__V1__QueryError         *message);
+size_t surrealdb__protocol__rpc__v1__query_error__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__QueryError   *message);
+size_t surrealdb__protocol__rpc__v1__query_error__pack
+                     (const Surrealdb__Protocol__Rpc__V1__QueryError   *message,
                       uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__relate_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__RelateRequest   *message,
+size_t surrealdb__protocol__rpc__v1__query_error__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__QueryError   *message,
                       ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__RelateRequest *
-       surrealdb__protocol__rpc__v1__relate_request__unpack
+Surrealdb__Protocol__Rpc__V1__QueryError *
+       surrealdb__protocol__rpc__v1__query_error__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__relate_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__RelateRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__RelateResponse methods */
-void   surrealdb__protocol__rpc__v1__relate_response__init
-                     (Surrealdb__Protocol__Rpc__V1__RelateResponse         *message);
-size_t surrealdb__protocol__rpc__v1__relate_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__RelateResponse   *message);
-size_t surrealdb__protocol__rpc__v1__relate_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__RelateResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__relate_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__RelateResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__RelateResponse *
-       surrealdb__protocol__rpc__v1__relate_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__relate_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__RelateResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__RunFunctionRequest methods */
-void   surrealdb__protocol__rpc__v1__run_function_request__init
-                     (Surrealdb__Protocol__Rpc__V1__RunFunctionRequest         *message);
-size_t surrealdb__protocol__rpc__v1__run_function_request__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest   *message);
-size_t surrealdb__protocol__rpc__v1__run_function_request__pack
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__run_function_request__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *
-       surrealdb__protocol__rpc__v1__run_function_request__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__run_function_request__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__RunFunctionResponse methods */
-void   surrealdb__protocol__rpc__v1__run_function_response__init
-                     (Surrealdb__Protocol__Rpc__V1__RunFunctionResponse         *message);
-size_t surrealdb__protocol__rpc__v1__run_function_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionResponse   *message);
-size_t surrealdb__protocol__rpc__v1__run_function_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__run_function_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__RunFunctionResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__RunFunctionResponse *
-       surrealdb__protocol__rpc__v1__run_function_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__run_function_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__RunFunctionResponse *message,
-                      ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__ValueBatch methods */
-void   surrealdb__protocol__rpc__v1__value_batch__init
-                     (Surrealdb__Protocol__Rpc__V1__ValueBatch         *message);
-size_t surrealdb__protocol__rpc__v1__value_batch__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__ValueBatch   *message);
-size_t surrealdb__protocol__rpc__v1__value_batch__pack
-                     (const Surrealdb__Protocol__Rpc__V1__ValueBatch   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__value_batch__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__ValueBatch   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__ValueBatch *
-       surrealdb__protocol__rpc__v1__value_batch__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__value_batch__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__ValueBatch *message,
+void   surrealdb__protocol__rpc__v1__query_error__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__QueryError *message,
                       ProtobufCAllocator *allocator);
 /* Surrealdb__Protocol__Rpc__V1__RootUserCredentials methods */
 void   surrealdb__protocol__rpc__v1__root_user_credentials__init
@@ -1954,25 +956,6 @@ Surrealdb__Protocol__Rpc__V1__AccessMethod *
 void   surrealdb__protocol__rpc__v1__access_method__free_unpacked
                      (Surrealdb__Protocol__Rpc__V1__AccessMethod *message,
                       ProtobufCAllocator *allocator);
-/* Surrealdb__Protocol__Rpc__V1__LiveResponse methods */
-void   surrealdb__protocol__rpc__v1__live_response__init
-                     (Surrealdb__Protocol__Rpc__V1__LiveResponse         *message);
-size_t surrealdb__protocol__rpc__v1__live_response__get_packed_size
-                     (const Surrealdb__Protocol__Rpc__V1__LiveResponse   *message);
-size_t surrealdb__protocol__rpc__v1__live_response__pack
-                     (const Surrealdb__Protocol__Rpc__V1__LiveResponse   *message,
-                      uint8_t             *out);
-size_t surrealdb__protocol__rpc__v1__live_response__pack_to_buffer
-                     (const Surrealdb__Protocol__Rpc__V1__LiveResponse   *message,
-                      ProtobufCBuffer     *buffer);
-Surrealdb__Protocol__Rpc__V1__LiveResponse *
-       surrealdb__protocol__rpc__v1__live_response__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data);
-void   surrealdb__protocol__rpc__v1__live_response__free_unpacked
-                     (Surrealdb__Protocol__Rpc__V1__LiveResponse *message,
-                      ProtobufCAllocator *allocator);
 /* Surrealdb__Protocol__Rpc__V1__Variables__VariablesEntry methods */
 void   surrealdb__protocol__rpc__v1__variables__variables_entry__init
                      (Surrealdb__Protocol__Rpc__V1__Variables__VariablesEntry         *message);
@@ -2009,18 +992,6 @@ typedef void (*Surrealdb__Protocol__Rpc__V1__VersionRequest_Closure)
 typedef void (*Surrealdb__Protocol__Rpc__V1__VersionResponse_Closure)
                  (const Surrealdb__Protocol__Rpc__V1__VersionResponse *message,
                   void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__InfoRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__InfoRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__InfoResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__InfoResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__UseRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__UseRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__UseResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__UseResponse *message,
-                  void *closure_data);
 typedef void (*Surrealdb__Protocol__Rpc__V1__SignupRequest_Closure)
                  (const Surrealdb__Protocol__Rpc__V1__SignupRequest *message,
                   void *closure_data);
@@ -2039,74 +1010,14 @@ typedef void (*Surrealdb__Protocol__Rpc__V1__AuthenticateRequest_Closure)
 typedef void (*Surrealdb__Protocol__Rpc__V1__AuthenticateResponse_Closure)
                  (const Surrealdb__Protocol__Rpc__V1__AuthenticateResponse *message,
                   void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__InvalidateRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__InvalidateRequest *message,
+typedef void (*Surrealdb__Protocol__Rpc__V1__SubscribeRequest_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__SubscribeRequest *message,
                   void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__InvalidateResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__InvalidateResponse *message,
+typedef void (*Surrealdb__Protocol__Rpc__V1__SubscribeResponse_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__SubscribeResponse *message,
                   void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__ResetRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__ResetRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__ResetResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__ResetResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__KillRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__KillRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__KillResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__KillResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__LiveRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__LiveRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__SetRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__SetRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__SetResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__SetResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__UnsetRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__UnsetRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__UnsetResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__UnsetResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__CreateRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__CreateRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__CreateResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__CreateResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__SelectRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__SelectRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__SelectResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__SelectResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__InsertRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__InsertRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__InsertResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__InsertResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__UpsertRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__UpsertRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__UpsertResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__UpsertResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__UpdateRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__UpdateRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__UpdateResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__UpdateResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__DeleteRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__DeleteRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__DeleteResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__DeleteResponse *message,
+typedef void (*Surrealdb__Protocol__Rpc__V1__Notification_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__Notification *message,
                   void *closure_data);
 typedef void (*Surrealdb__Protocol__Rpc__V1__QueryRequest_Closure)
                  (const Surrealdb__Protocol__Rpc__V1__QueryRequest *message,
@@ -2117,20 +1028,8 @@ typedef void (*Surrealdb__Protocol__Rpc__V1__QueryResponse_Closure)
 typedef void (*Surrealdb__Protocol__Rpc__V1__QueryStats_Closure)
                  (const Surrealdb__Protocol__Rpc__V1__QueryStats *message,
                   void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__RelateRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__RelateRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__RelateResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__RelateResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__RunFunctionRequest_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__RunFunctionResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__RunFunctionResponse *message,
-                  void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__ValueBatch_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__ValueBatch *message,
+typedef void (*Surrealdb__Protocol__Rpc__V1__QueryError_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__QueryError *message,
                   void *closure_data);
 typedef void (*Surrealdb__Protocol__Rpc__V1__RootUserCredentials_Closure)
                  (const Surrealdb__Protocol__Rpc__V1__RootUserCredentials *message,
@@ -2153,9 +1052,6 @@ typedef void (*Surrealdb__Protocol__Rpc__V1__AccessToken_Closure)
 typedef void (*Surrealdb__Protocol__Rpc__V1__AccessMethod_Closure)
                  (const Surrealdb__Protocol__Rpc__V1__AccessMethod *message,
                   void *closure_data);
-typedef void (*Surrealdb__Protocol__Rpc__V1__LiveResponse_Closure)
-                 (const Surrealdb__Protocol__Rpc__V1__LiveResponse *message,
-                  void *closure_data);
 typedef void (*Surrealdb__Protocol__Rpc__V1__Variables__VariablesEntry_Closure)
                  (const Surrealdb__Protocol__Rpc__V1__Variables__VariablesEntry *message,
                   void *closure_data);
@@ -2177,22 +1073,6 @@ struct Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service
                   const Surrealdb__Protocol__Rpc__V1__VersionRequest *input,
                   Surrealdb__Protocol__Rpc__V1__VersionResponse_Closure closure,
                   void *closure_data);
-  void (*info)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-               const Surrealdb__Protocol__Rpc__V1__InfoRequest *input,
-               Surrealdb__Protocol__Rpc__V1__InfoResponse_Closure closure,
-               void *closure_data);
-  void (*query)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                const Surrealdb__Protocol__Rpc__V1__QueryRequest *input,
-                Surrealdb__Protocol__Rpc__V1__QueryResponse_Closure closure,
-                void *closure_data);
-  void (*live)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-               const Surrealdb__Protocol__Rpc__V1__LiveRequest *input,
-               Surrealdb__Protocol__Rpc__V1__LiveResponse_Closure closure,
-               void *closure_data);
-  void (*use)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-              const Surrealdb__Protocol__Rpc__V1__UseRequest *input,
-              Surrealdb__Protocol__Rpc__V1__UseResponse_Closure closure,
-              void *closure_data);
   void (*signup)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
                  const Surrealdb__Protocol__Rpc__V1__SignupRequest *input,
                  Surrealdb__Protocol__Rpc__V1__SignupResponse_Closure closure,
@@ -2205,58 +1085,14 @@ struct Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service
                        const Surrealdb__Protocol__Rpc__V1__AuthenticateRequest *input,
                        Surrealdb__Protocol__Rpc__V1__AuthenticateResponse_Closure closure,
                        void *closure_data);
-  void (*invalidate)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                     const Surrealdb__Protocol__Rpc__V1__InvalidateRequest *input,
-                     Surrealdb__Protocol__Rpc__V1__InvalidateResponse_Closure closure,
-                     void *closure_data);
-  void (*reset)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                const Surrealdb__Protocol__Rpc__V1__ResetRequest *input,
-                Surrealdb__Protocol__Rpc__V1__ResetResponse_Closure closure,
+  void (*query)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
+                const Surrealdb__Protocol__Rpc__V1__QueryRequest *input,
+                Surrealdb__Protocol__Rpc__V1__QueryResponse_Closure closure,
                 void *closure_data);
-  void (*kill)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-               const Surrealdb__Protocol__Rpc__V1__KillRequest *input,
-               Surrealdb__Protocol__Rpc__V1__KillResponse_Closure closure,
-               void *closure_data);
-  void (*set)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-              const Surrealdb__Protocol__Rpc__V1__SetRequest *input,
-              Surrealdb__Protocol__Rpc__V1__SetResponse_Closure closure,
-              void *closure_data);
-  void (*unset)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                const Surrealdb__Protocol__Rpc__V1__UnsetRequest *input,
-                Surrealdb__Protocol__Rpc__V1__UnsetResponse_Closure closure,
-                void *closure_data);
-  void (*select)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                 const Surrealdb__Protocol__Rpc__V1__SelectRequest *input,
-                 Surrealdb__Protocol__Rpc__V1__SelectResponse_Closure closure,
-                 void *closure_data);
-  void (*create)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                 const Surrealdb__Protocol__Rpc__V1__CreateRequest *input,
-                 Surrealdb__Protocol__Rpc__V1__CreateResponse_Closure closure,
-                 void *closure_data);
-  void (*insert)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                 const Surrealdb__Protocol__Rpc__V1__InsertRequest *input,
-                 Surrealdb__Protocol__Rpc__V1__InsertResponse_Closure closure,
-                 void *closure_data);
-  void (*upsert)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                 const Surrealdb__Protocol__Rpc__V1__UpsertRequest *input,
-                 Surrealdb__Protocol__Rpc__V1__UpsertResponse_Closure closure,
-                 void *closure_data);
-  void (*update)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                 const Surrealdb__Protocol__Rpc__V1__UpdateRequest *input,
-                 Surrealdb__Protocol__Rpc__V1__UpdateResponse_Closure closure,
-                 void *closure_data);
-  void (*delete)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                 const Surrealdb__Protocol__Rpc__V1__DeleteRequest *input,
-                 Surrealdb__Protocol__Rpc__V1__DeleteResponse_Closure closure,
-                 void *closure_data);
-  void (*relate)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                 const Surrealdb__Protocol__Rpc__V1__RelateRequest *input,
-                 Surrealdb__Protocol__Rpc__V1__RelateResponse_Closure closure,
-                 void *closure_data);
-  void (*run_function)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
-                       const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *input,
-                       Surrealdb__Protocol__Rpc__V1__RunFunctionResponse_Closure closure,
-                       void *closure_data);
+  void (*subscribe)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
+                    const Surrealdb__Protocol__Rpc__V1__SubscribeRequest *input,
+                    Surrealdb__Protocol__Rpc__V1__SubscribeResponse_Closure closure,
+                    void *closure_data);
 };
 typedef void (*Surrealdb__Protocol__Rpc__V1__SurrealDBService_ServiceDestroy)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *);
 void surrealdb__protocol__rpc__v1__surreal_dbservice__init (Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
@@ -2267,26 +1103,11 @@ void surrealdb__protocol__rpc__v1__surreal_dbservice__init (Surrealdb__Protocol_
     { SURREALDB__PROTOCOL__RPC__V1__SURREAL_DBSERVICE__BASE_INIT,\
       function_prefix__ ## health,\
       function_prefix__ ## version,\
-      function_prefix__ ## info,\
-      function_prefix__ ## query,\
-      function_prefix__ ## live,\
-      function_prefix__ ## use,\
       function_prefix__ ## signup,\
       function_prefix__ ## signin,\
       function_prefix__ ## authenticate,\
-      function_prefix__ ## invalidate,\
-      function_prefix__ ## reset,\
-      function_prefix__ ## kill,\
-      function_prefix__ ## set,\
-      function_prefix__ ## unset,\
-      function_prefix__ ## select,\
-      function_prefix__ ## create,\
-      function_prefix__ ## insert,\
-      function_prefix__ ## upsert,\
-      function_prefix__ ## update,\
-      function_prefix__ ## delete,\
-      function_prefix__ ## relate,\
-      function_prefix__ ## run_function  }
+      function_prefix__ ## query,\
+      function_prefix__ ## subscribe  }
 void surrealdb__protocol__rpc__v1__surreal_dbservice__health(ProtobufCService *service,
                                                              const Surrealdb__Protocol__Rpc__V1__HealthRequest *input,
                                                              Surrealdb__Protocol__Rpc__V1__HealthResponse_Closure closure,
@@ -2295,22 +1116,6 @@ void surrealdb__protocol__rpc__v1__surreal_dbservice__version(ProtobufCService *
                                                               const Surrealdb__Protocol__Rpc__V1__VersionRequest *input,
                                                               Surrealdb__Protocol__Rpc__V1__VersionResponse_Closure closure,
                                                               void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__info(ProtobufCService *service,
-                                                           const Surrealdb__Protocol__Rpc__V1__InfoRequest *input,
-                                                           Surrealdb__Protocol__Rpc__V1__InfoResponse_Closure closure,
-                                                           void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__query(ProtobufCService *service,
-                                                            const Surrealdb__Protocol__Rpc__V1__QueryRequest *input,
-                                                            Surrealdb__Protocol__Rpc__V1__QueryResponse_Closure closure,
-                                                            void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__live(ProtobufCService *service,
-                                                           const Surrealdb__Protocol__Rpc__V1__LiveRequest *input,
-                                                           Surrealdb__Protocol__Rpc__V1__LiveResponse_Closure closure,
-                                                           void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__use(ProtobufCService *service,
-                                                          const Surrealdb__Protocol__Rpc__V1__UseRequest *input,
-                                                          Surrealdb__Protocol__Rpc__V1__UseResponse_Closure closure,
-                                                          void *closure_data);
 void surrealdb__protocol__rpc__v1__surreal_dbservice__signup(ProtobufCService *service,
                                                              const Surrealdb__Protocol__Rpc__V1__SignupRequest *input,
                                                              Surrealdb__Protocol__Rpc__V1__SignupResponse_Closure closure,
@@ -2323,58 +1128,14 @@ void surrealdb__protocol__rpc__v1__surreal_dbservice__authenticate(ProtobufCServ
                                                                    const Surrealdb__Protocol__Rpc__V1__AuthenticateRequest *input,
                                                                    Surrealdb__Protocol__Rpc__V1__AuthenticateResponse_Closure closure,
                                                                    void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__invalidate(ProtobufCService *service,
-                                                                 const Surrealdb__Protocol__Rpc__V1__InvalidateRequest *input,
-                                                                 Surrealdb__Protocol__Rpc__V1__InvalidateResponse_Closure closure,
-                                                                 void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__reset(ProtobufCService *service,
-                                                            const Surrealdb__Protocol__Rpc__V1__ResetRequest *input,
-                                                            Surrealdb__Protocol__Rpc__V1__ResetResponse_Closure closure,
+void surrealdb__protocol__rpc__v1__surreal_dbservice__query(ProtobufCService *service,
+                                                            const Surrealdb__Protocol__Rpc__V1__QueryRequest *input,
+                                                            Surrealdb__Protocol__Rpc__V1__QueryResponse_Closure closure,
                                                             void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__kill(ProtobufCService *service,
-                                                           const Surrealdb__Protocol__Rpc__V1__KillRequest *input,
-                                                           Surrealdb__Protocol__Rpc__V1__KillResponse_Closure closure,
-                                                           void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__set(ProtobufCService *service,
-                                                          const Surrealdb__Protocol__Rpc__V1__SetRequest *input,
-                                                          Surrealdb__Protocol__Rpc__V1__SetResponse_Closure closure,
-                                                          void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__unset(ProtobufCService *service,
-                                                            const Surrealdb__Protocol__Rpc__V1__UnsetRequest *input,
-                                                            Surrealdb__Protocol__Rpc__V1__UnsetResponse_Closure closure,
-                                                            void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__select(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__SelectRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__SelectResponse_Closure closure,
-                                                             void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__create(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__CreateRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__CreateResponse_Closure closure,
-                                                             void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__insert(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__InsertRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__InsertResponse_Closure closure,
-                                                             void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__upsert(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__UpsertRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__UpsertResponse_Closure closure,
-                                                             void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__update(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__UpdateRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__UpdateResponse_Closure closure,
-                                                             void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__delete(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__DeleteRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__DeleteResponse_Closure closure,
-                                                             void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__relate(ProtobufCService *service,
-                                                             const Surrealdb__Protocol__Rpc__V1__RelateRequest *input,
-                                                             Surrealdb__Protocol__Rpc__V1__RelateResponse_Closure closure,
-                                                             void *closure_data);
-void surrealdb__protocol__rpc__v1__surreal_dbservice__run_function(ProtobufCService *service,
-                                                                   const Surrealdb__Protocol__Rpc__V1__RunFunctionRequest *input,
-                                                                   Surrealdb__Protocol__Rpc__V1__RunFunctionResponse_Closure closure,
-                                                                   void *closure_data);
+void surrealdb__protocol__rpc__v1__surreal_dbservice__subscribe(ProtobufCService *service,
+                                                                const Surrealdb__Protocol__Rpc__V1__SubscribeRequest *input,
+                                                                Surrealdb__Protocol__Rpc__V1__SubscribeResponse_Closure closure,
+                                                                void *closure_data);
 
 /* --- descriptors --- */
 
@@ -2383,47 +1144,19 @@ extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__health_req
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__health_response__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__version_request__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__version_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__info_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__info_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__use_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__use_response__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__signup_request__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__signup_response__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__signin_request__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__signin_response__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__authenticate_request__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__authenticate_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__invalidate_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__invalidate_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__reset_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__reset_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__kill_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__kill_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__live_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__set_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__set_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__unset_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__unset_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__create_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__create_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__select_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__select_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__insert_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__insert_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__upsert_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__upsert_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__update_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__update_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__delete_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__delete_response__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__subscribe_request__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__subscribe_response__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__notification__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__query_request__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__query_response__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__query_stats__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__relate_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__relate_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__run_function_request__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__run_function_response__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__value_batch__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__query_error__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__root_user_credentials__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__namespace_access_credentials__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__database_access_credentials__descriptor;
@@ -2431,7 +1164,6 @@ extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__namespace_
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__database_user_credentials__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__access_token__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__access_method__descriptor;
-extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__live_response__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__variables__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__variables__variables_entry__descriptor;
 extern const ProtobufCServiceDescriptor surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor;

--- a/gen/rust/fb/surrealdb/protocol/v_1/value_generated.rs
+++ b/gen/rust/fb/surrealdb/protocol/v_1/value_generated.rs
@@ -195,8 +195,8 @@ impl<'a> Value<'a> {
 
   #[inline]
   #[allow(non_snake_case)]
-  pub fn value_as_timestamp(&self) -> Option<Timestamp<'a>> {
-    if self.value_type() == ValueType::Timestamp {
+  pub fn value_as_datetime(&self) -> Option<Timestamp<'a>> {
+    if self.value_type() == ValueType::Datetime {
       self.value().map(|t| {
        // Safety:
        // Created from a valid Table for this object
@@ -318,7 +318,7 @@ impl flatbuffers::Verifiable for Value<'_> {
           ValueType::Bytes => v.verify_union_variant::<flatbuffers::ForwardsUOffset<Bytes>>("ValueType::Bytes", pos),
           ValueType::Decimal => v.verify_union_variant::<flatbuffers::ForwardsUOffset<Decimal>>("ValueType::Decimal", pos),
           ValueType::Duration => v.verify_union_variant::<flatbuffers::ForwardsUOffset<Duration>>("ValueType::Duration", pos),
-          ValueType::Timestamp => v.verify_union_variant::<flatbuffers::ForwardsUOffset<Timestamp>>("ValueType::Timestamp", pos),
+          ValueType::Datetime => v.verify_union_variant::<flatbuffers::ForwardsUOffset<Timestamp>>("ValueType::Datetime", pos),
           ValueType::Uuid => v.verify_union_variant::<flatbuffers::ForwardsUOffset<Uuid>>("ValueType::Uuid", pos),
           ValueType::Array => v.verify_union_variant::<flatbuffers::ForwardsUOffset<Array>>("ValueType::Array", pos),
           ValueType::Object => v.verify_union_variant::<flatbuffers::ForwardsUOffset<Object>>("ValueType::Object", pos),
@@ -442,8 +442,8 @@ impl core::fmt::Debug for Value<'_> {
             ds.field("value", &"InvalidFlatbuffer: Union discriminant does not match value.")
           }
         },
-        ValueType::Timestamp => {
-          if let Some(x) = self.value_as_timestamp() {
+        ValueType::Datetime => {
+          if let Some(x) = self.value_as_datetime() {
             ds.field("value", &x)
           } else {
             ds.field("value", &"InvalidFlatbuffer: Union discriminant does not match value.")

--- a/gen/rust/fb/surrealdb/protocol/v_1/value_type_generated.rs
+++ b/gen/rust/fb/surrealdb/protocol/v_1/value_type_generated.rs
@@ -26,7 +26,7 @@ pub const ENUM_VALUES_VALUE_TYPE: [ValueType; 17] = [
   ValueType::Bytes,
   ValueType::Decimal,
   ValueType::Duration,
-  ValueType::Timestamp,
+  ValueType::Datetime,
   ValueType::Uuid,
   ValueType::Array,
   ValueType::Object,
@@ -50,7 +50,7 @@ impl ValueType {
   pub const Bytes: Self = Self(7);
   pub const Decimal: Self = Self(8);
   pub const Duration: Self = Self(9);
-  pub const Timestamp: Self = Self(10);
+  pub const Datetime: Self = Self(10);
   pub const Uuid: Self = Self(11);
   pub const Array: Self = Self(12);
   pub const Object: Self = Self(13);
@@ -71,7 +71,7 @@ impl ValueType {
     Self::Bytes,
     Self::Decimal,
     Self::Duration,
-    Self::Timestamp,
+    Self::Datetime,
     Self::Uuid,
     Self::Array,
     Self::Object,
@@ -92,7 +92,7 @@ impl ValueType {
       Self::Bytes => Some("Bytes"),
       Self::Decimal => Some("Decimal"),
       Self::Duration => Some("Duration"),
-      Self::Timestamp => Some("Timestamp"),
+      Self::Datetime => Some("Datetime"),
       Self::Uuid => Some("Uuid"),
       Self::Array => Some("Array"),
       Self::Object => Some("Object"),

--- a/gen/rust/proto/surrealdb.protocol.rpc.v1.rs
+++ b/gen/rust/proto/surrealdb.protocol.rpc.v1.rs
@@ -38,50 +38,6 @@ impl ::prost::Name for VersionResponse {
 const NAME: &'static str = "VersionResponse";
 const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
 fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.VersionResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.VersionResponse".into() }}
-/// Request to get information about the database.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct InfoRequest {
-}
-impl ::prost::Name for InfoRequest {
-const NAME: &'static str = "InfoRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.InfoRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.InfoRequest".into() }}
-/// Response to an info request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InfoResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for InfoResponse {
-const NAME: &'static str = "InfoResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.InfoResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.InfoResponse".into() }}
-/// Request to change the current namespace and database.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UseRequest {
-    #[prost(string, tag="1")]
-    pub namespace: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub database: ::prost::alloc::string::String,
-}
-impl ::prost::Name for UseRequest {
-const NAME: &'static str = "UseRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UseRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UseRequest".into() }}
-/// Response to a use request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UseResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for UseResponse {
-const NAME: &'static str = "UseResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UseResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UseResponse".into() }}
 /// Request to sign up a new user.
 #[derive(serde::Deserialize,serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -104,7 +60,7 @@ fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.Si
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignupResponse {
     #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
+    pub value: ::core::option::Option<super::super::v1::Value>,
 }
 impl ::prost::Name for SignupResponse {
 const NAME: &'static str = "SignupResponse";
@@ -126,7 +82,7 @@ fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.Si
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SigninResponse {
     #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
+    pub value: ::core::option::Option<super::super::v1::Value>,
 }
 impl ::prost::Name for SigninResponse {
 const NAME: &'static str = "SigninResponse";
@@ -148,403 +104,53 @@ fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.Au
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthenticateResponse {
     #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
+    pub value: ::core::option::Option<super::super::v1::Value>,
 }
 impl ::prost::Name for AuthenticateResponse {
 const NAME: &'static str = "AuthenticateResponse";
 const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
 fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.AuthenticateResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.AuthenticateResponse".into() }}
-/// Request to invalidate a user.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct InvalidateRequest {
-}
-impl ::prost::Name for InvalidateRequest {
-const NAME: &'static str = "InvalidateRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.InvalidateRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.InvalidateRequest".into() }}
-/// Response to an invalidate request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InvalidateResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for InvalidateResponse {
-const NAME: &'static str = "InvalidateResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.InvalidateResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.InvalidateResponse".into() }}
-/// Request to reset the database.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct ResetRequest {
-}
-impl ::prost::Name for ResetRequest {
-const NAME: &'static str = "ResetRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.ResetRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.ResetRequest".into() }}
-/// Response to a reset request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ResetResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for ResetResponse {
-const NAME: &'static str = "ResetResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.ResetResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.ResetResponse".into() }}
-/// Request to kill a live query.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct KillRequest {
-    #[prost(string, tag="1")]
-    pub live_id: ::prost::alloc::string::String,
-}
-impl ::prost::Name for KillRequest {
-const NAME: &'static str = "KillRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.KillRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.KillRequest".into() }}
-/// Response to a kill request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct KillResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for KillResponse {
-const NAME: &'static str = "KillResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.KillResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.KillResponse".into() }}
 /// Request to issue a live query.
 #[derive(serde::Deserialize,serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct LiveRequest {
-    #[prost(message, optional, tag="1")]
-    pub what: ::core::option::Option<super::super::v1::Value>,
+pub struct SubscribeRequest {
+    #[prost(string, tag="1")]
+    pub query: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub expr: ::core::option::Option<super::super::v1::Fields>,
-    #[prost(message, optional, tag="3")]
-    pub cond: ::core::option::Option<super::super::v1::Value>,
+    pub variables: ::core::option::Option<Variables>,
 }
-impl ::prost::Name for LiveRequest {
-const NAME: &'static str = "LiveRequest";
+impl ::prost::Name for SubscribeRequest {
+const NAME: &'static str = "SubscribeRequest";
 const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.LiveRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.LiveRequest".into() }}
-/// Request to set a value.
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.SubscribeRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.SubscribeRequest".into() }}
+/// Response to a live query.
 #[derive(serde::Deserialize,serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SetRequest {
-    #[prost(string, tag="1")]
-    pub key: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="2")]
+pub struct SubscribeResponse {
+    #[prost(message, optional, tag="1")]
+    pub notification: ::core::option::Option<Notification>,
+}
+impl ::prost::Name for SubscribeResponse {
+const NAME: &'static str = "SubscribeResponse";
+const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.SubscribeResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.SubscribeResponse".into() }}
+/// A notification from a live query.
+#[derive(serde::Deserialize,serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Notification {
+    #[prost(message, optional, tag="1")]
+    pub live_query_id: ::core::option::Option<super::super::v1::Uuid>,
+    #[prost(enumeration="Action", tag="2")]
+    pub action: i32,
+    #[prost(message, optional, tag="3")]
+    pub record_id: ::core::option::Option<super::super::v1::RecordId>,
+    #[prost(message, optional, tag="4")]
     pub value: ::core::option::Option<super::super::v1::Value>,
 }
-impl ::prost::Name for SetRequest {
-const NAME: &'static str = "SetRequest";
+impl ::prost::Name for Notification {
+const NAME: &'static str = "Notification";
 const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.SetRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.SetRequest".into() }}
-/// Response to a set request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SetResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for SetResponse {
-const NAME: &'static str = "SetResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.SetResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.SetResponse".into() }}
-/// Request to unset a value.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UnsetRequest {
-    #[prost(string, tag="1")]
-    pub key: ::prost::alloc::string::String,
-}
-impl ::prost::Name for UnsetRequest {
-const NAME: &'static str = "UnsetRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UnsetRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UnsetRequest".into() }}
-/// Response to an unset request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UnsetResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for UnsetResponse {
-const NAME: &'static str = "UnsetResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UnsetResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UnsetResponse".into() }}
-/// Request to create a new record.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CreateRequest {
-    #[prost(message, optional, tag="1")]
-    pub txn: ::core::option::Option<super::super::v1::Uuid>,
-    #[prost(bool, tag="2")]
-    pub only: bool,
-    #[prost(message, repeated, tag="3")]
-    pub what: ::prost::alloc::vec::Vec<super::super::v1::Value>,
-    #[prost(message, optional, tag="4")]
-    pub data: ::core::option::Option<super::super::v1::Data>,
-    #[prost(message, optional, tag="5")]
-    pub output: ::core::option::Option<super::super::v1::Output>,
-    #[prost(message, optional, tag="6")]
-    #[serde(with = "crate::serde_duration_optional")]
-    pub timeout: ::core::option::Option<::prost_types::Duration>,
-    #[prost(bool, tag="7")]
-    pub parallel: bool,
-    #[prost(message, optional, tag="8")]
-    pub version: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="9")]
-    pub variables: ::core::option::Option<Variables>,
-}
-impl ::prost::Name for CreateRequest {
-const NAME: &'static str = "CreateRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.CreateRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.CreateRequest".into() }}
-/// Response to a create request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CreateResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for CreateResponse {
-const NAME: &'static str = "CreateResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.CreateResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.CreateResponse".into() }}
-/// Request to select values from the database.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SelectRequest {
-    #[prost(message, optional, tag="1")]
-    pub txn: ::core::option::Option<super::super::v1::Uuid>,
-    #[prost(message, optional, tag="2")]
-    pub expr: ::core::option::Option<super::super::v1::Fields>,
-    #[prost(message, optional, tag="3")]
-    pub omit: ::core::option::Option<super::super::v1::Value>,
-    #[prost(bool, tag="4")]
-    pub only: bool,
-    #[prost(message, repeated, tag="5")]
-    pub what: ::prost::alloc::vec::Vec<super::super::v1::Value>,
-    #[prost(message, optional, tag="6")]
-    pub with: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="7")]
-    pub cond: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="8")]
-    pub split: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="9")]
-    pub group: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="10")]
-    pub order: ::core::option::Option<super::super::v1::Value>,
-    #[prost(int64, tag="11")]
-    pub start: i64,
-    #[prost(int64, tag="12")]
-    pub limit: i64,
-    #[prost(message, optional, tag="13")]
-    pub fetch: ::core::option::Option<super::super::v1::Fetchs>,
-    #[prost(message, optional, tag="14")]
-    pub version: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="15")]
-    #[serde(with = "crate::serde_duration_optional")]
-    pub timeout: ::core::option::Option<::prost_types::Duration>,
-    #[prost(bool, tag="16")]
-    pub parallel: bool,
-    #[prost(message, optional, tag="17")]
-    pub explain: ::core::option::Option<super::super::v1::Explain>,
-    #[prost(bool, tag="18")]
-    pub tempfiles: bool,
-    #[prost(message, optional, tag="19")]
-    pub variables: ::core::option::Option<Variables>,
-}
-impl ::prost::Name for SelectRequest {
-const NAME: &'static str = "SelectRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.SelectRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.SelectRequest".into() }}
-/// Response to a select request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SelectResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for SelectResponse {
-const NAME: &'static str = "SelectResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.SelectResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.SelectResponse".into() }}
-/// Request to insert a new record.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InsertRequest {
-    #[prost(message, optional, tag="1")]
-    pub txn: ::core::option::Option<super::super::v1::Uuid>,
-    #[prost(message, optional, tag="2")]
-    pub into: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="3")]
-    pub data: ::core::option::Option<super::super::v1::Data>,
-    #[prost(bool, tag="4")]
-    pub ignore: bool,
-    #[prost(message, optional, tag="5")]
-    pub update: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="6")]
-    pub output: ::core::option::Option<super::super::v1::Output>,
-    #[prost(message, optional, tag="7")]
-    #[serde(with = "crate::serde_duration_optional")]
-    pub timeout: ::core::option::Option<::prost_types::Duration>,
-    #[prost(bool, tag="8")]
-    pub parallel: bool,
-    #[prost(bool, tag="9")]
-    pub relation: bool,
-    #[prost(message, optional, tag="10")]
-    pub version: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="11")]
-    pub variables: ::core::option::Option<Variables>,
-}
-impl ::prost::Name for InsertRequest {
-const NAME: &'static str = "InsertRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.InsertRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.InsertRequest".into() }}
-/// Response to an insert request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct InsertResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for InsertResponse {
-const NAME: &'static str = "InsertResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.InsertResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.InsertResponse".into() }}
-/// Request to upsert a record.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UpsertRequest {
-    #[prost(message, optional, tag="1")]
-    pub txn: ::core::option::Option<super::super::v1::Uuid>,
-    #[prost(bool, tag="2")]
-    pub only: bool,
-    #[prost(message, repeated, tag="3")]
-    pub what: ::prost::alloc::vec::Vec<super::super::v1::Value>,
-    #[prost(message, optional, tag="4")]
-    pub with: ::core::option::Option<super::super::v1::With>,
-    #[prost(message, optional, tag="5")]
-    pub data: ::core::option::Option<super::super::v1::Data>,
-    #[prost(message, optional, tag="6")]
-    pub cond: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="7")]
-    pub output: ::core::option::Option<super::super::v1::Output>,
-    #[prost(message, optional, tag="8")]
-    #[serde(with = "crate::serde_duration_optional")]
-    pub timeout: ::core::option::Option<::prost_types::Duration>,
-    #[prost(bool, tag="9")]
-    pub parallel: bool,
-    #[prost(message, optional, tag="10")]
-    pub explain: ::core::option::Option<super::super::v1::Explain>,
-    #[prost(message, optional, tag="11")]
-    pub variables: ::core::option::Option<Variables>,
-}
-impl ::prost::Name for UpsertRequest {
-const NAME: &'static str = "UpsertRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UpsertRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UpsertRequest".into() }}
-/// Response to an upsert request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UpsertResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for UpsertResponse {
-const NAME: &'static str = "UpsertResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UpsertResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UpsertResponse".into() }}
-/// Request to update a record.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UpdateRequest {
-    #[prost(message, optional, tag="1")]
-    pub txn: ::core::option::Option<super::super::v1::Uuid>,
-    #[prost(bool, tag="2")]
-    pub only: bool,
-    #[prost(message, repeated, tag="3")]
-    pub what: ::prost::alloc::vec::Vec<super::super::v1::Value>,
-    #[prost(message, optional, tag="4")]
-    pub with: ::core::option::Option<super::super::v1::With>,
-    #[prost(message, optional, tag="5")]
-    pub data: ::core::option::Option<super::super::v1::Data>,
-    #[prost(message, optional, tag="6")]
-    pub cond: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="7")]
-    pub output: ::core::option::Option<super::super::v1::Output>,
-    #[prost(message, optional, tag="9")]
-    #[serde(with = "crate::serde_duration_optional")]
-    pub timeout: ::core::option::Option<::prost_types::Duration>,
-    #[prost(bool, tag="10")]
-    pub parallel: bool,
-    #[prost(message, optional, tag="11")]
-    pub explain: ::core::option::Option<super::super::v1::Explain>,
-    #[prost(message, optional, tag="12")]
-    pub variables: ::core::option::Option<Variables>,
-}
-impl ::prost::Name for UpdateRequest {
-const NAME: &'static str = "UpdateRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UpdateRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UpdateRequest".into() }}
-/// Response to an update request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UpdateResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for UpdateResponse {
-const NAME: &'static str = "UpdateResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UpdateResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UpdateResponse".into() }}
-/// Request to delete a record.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteRequest {
-    #[prost(message, optional, tag="1")]
-    pub txn: ::core::option::Option<super::super::v1::Uuid>,
-    #[prost(bool, tag="2")]
-    pub only: bool,
-    #[prost(message, repeated, tag="3")]
-    pub what: ::prost::alloc::vec::Vec<super::super::v1::Value>,
-    #[prost(message, optional, tag="4")]
-    pub with: ::core::option::Option<super::super::v1::With>,
-    #[prost(message, optional, tag="5")]
-    pub cond: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="6")]
-    pub output: ::core::option::Option<super::super::v1::Output>,
-    #[prost(message, optional, tag="7")]
-    #[serde(with = "crate::serde_duration_optional")]
-    pub timeout: ::core::option::Option<::prost_types::Duration>,
-    #[prost(bool, tag="8")]
-    pub parallel: bool,
-    #[prost(message, optional, tag="9")]
-    pub explain: ::core::option::Option<super::super::v1::Explain>,
-    #[prost(message, optional, tag="10")]
-    pub variables: ::core::option::Option<Variables>,
-}
-impl ::prost::Name for DeleteRequest {
-const NAME: &'static str = "DeleteRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.DeleteRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.DeleteRequest".into() }}
-/// Response to a delete request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DeleteResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for DeleteResponse {
-const NAME: &'static str = "DeleteResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.DeleteResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.DeleteResponse".into() }}
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.Notification".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.Notification".into() }}
 /// Request to query the database.
 #[derive(serde::Deserialize,serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -567,14 +173,14 @@ fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.Qu
 /// value batches may elide the stats.
 /// 
 /// Responses are ordered by query index, then batch index. For example:
-///   QueryResponse(query_index=0, batch_index=0)
-///   QueryResponse(query_index=0, batch_index=1)
-///   QueryResponse(query_index=1, batch_index=0)
-///   QueryResponse(query_index=2, batch_index=0)
-///   QueryResponse(query_index=2, batch_index=1)
-///   QueryResponse(query_index=2, batch_index=2)
-///   QueryResponse(query_index=3, batch_index=0)
-///   QueryResponse(query_index=4, batch_index=0)
+///   QueryResponse(query_index=0, batch_index=0, stats=None)
+///   QueryResponse(query_index=0, batch_index=1, stats=Some(..))
+///   QueryResponse(query_index=1, batch_index=0, stats=Some(..))
+///   QueryResponse(query_index=2, batch_index=0, stats=None)
+///   QueryResponse(query_index=2, batch_index=1, stats=None)
+///   QueryResponse(query_index=2, batch_index=2, stats=Some(..))
+///   QueryResponse(query_index=3, batch_index=0, stats=Some(..))
+///   QueryResponse(query_index=4, batch_index=0, stats=Some(..))
 #[derive(serde::Deserialize,serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryResponse {
@@ -585,11 +191,15 @@ pub struct QueryResponse {
     #[prost(uint64, tag="2")]
     pub batch_index: u64,
     /// The query stats.
+    /// This is only expected to be present in the last batch of each query.
     #[prost(message, optional, tag="3")]
     pub stats: ::core::option::Option<QueryStats>,
-    /// The value batch.
+    /// The error, if any.
     #[prost(message, optional, tag="4")]
-    pub values: ::core::option::Option<ValueBatch>,
+    pub error: ::core::option::Option<QueryError>,
+    /// A batch of values.
+    #[prost(message, repeated, tag="5")]
+    pub values: ::prost::alloc::vec::Vec<super::super::v1::Value>,
 }
 impl ::prost::Name for QueryResponse {
 const NAME: &'static str = "QueryResponse";
@@ -601,13 +211,22 @@ fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.Qu
 pub struct QueryStats {
     /// The number of records returned. -1 if unknown.
     #[prost(int64, tag="1")]
-    pub num_records: i64,
+    pub records_returned: i64,
+    /// The number of bytes returned. -1 if unknown.
+    #[prost(int64, tag="2")]
+    pub bytes_returned: i64,
+    /// The number of records scanned. -1 if unknown.
+    #[prost(int64, tag="3")]
+    pub records_scanned: i64,
+    /// The number of bytes scanned. -1 if unknown.
+    #[prost(int64, tag="4")]
+    pub bytes_scanned: i64,
     /// The start time of the query.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag="5")]
     #[serde(with = "crate::serde_timestamp_optional")]
     pub start_time: ::core::option::Option<::prost_types::Timestamp>,
     /// The duration of the query.
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag="6")]
     #[serde(with = "crate::serde_duration_optional")]
     pub execution_duration: ::core::option::Option<::prost_types::Duration>,
 }
@@ -615,86 +234,21 @@ impl ::prost::Name for QueryStats {
 const NAME: &'static str = "QueryStats";
 const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
 fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.QueryStats".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.QueryStats".into() }}
-/// Request to relate two records.
+/// Query error.
 #[derive(serde::Deserialize,serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RelateRequest {
-    #[prost(message, optional, tag="1")]
-    pub txn: ::core::option::Option<super::super::v1::Uuid>,
-    #[prost(bool, tag="2")]
-    pub only: bool,
-    #[prost(message, optional, tag="3")]
-    pub kind: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="4")]
-    pub from: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="5")]
-    pub with: ::core::option::Option<super::super::v1::Value>,
-    #[prost(bool, tag="6")]
-    pub uniq: bool,
-    #[prost(message, optional, tag="7")]
-    pub data: ::core::option::Option<super::super::v1::Data>,
-    #[prost(message, optional, tag="8")]
-    pub output: ::core::option::Option<super::super::v1::Output>,
-    #[prost(message, optional, tag="9")]
-    #[serde(with = "crate::serde_duration_optional")]
-    pub timeout: ::core::option::Option<::prost_types::Duration>,
-    #[prost(bool, tag="10")]
-    pub parallel: bool,
-    #[prost(message, optional, tag="11")]
-    pub variables: ::core::option::Option<Variables>,
-}
-impl ::prost::Name for RelateRequest {
-const NAME: &'static str = "RelateRequest";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.RelateRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.RelateRequest".into() }}
-/// Response to a relate request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RelateResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for RelateResponse {
-const NAME: &'static str = "RelateResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.RelateResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.RelateResponse".into() }}
-/// Request to run a function.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RunFunctionRequest {
-    #[prost(string, tag="1")]
-    pub name: ::prost::alloc::string::String,
+pub struct QueryError {
+    /// The error code.
+    #[prost(int64, tag="1")]
+    pub code: i64,
+    /// The error message.
     #[prost(string, tag="2")]
-    pub version: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag="3")]
-    pub args: ::prost::alloc::vec::Vec<super::super::v1::Value>,
+    pub message: ::prost::alloc::string::String,
 }
-impl ::prost::Name for RunFunctionRequest {
-const NAME: &'static str = "RunFunctionRequest";
+impl ::prost::Name for QueryError {
+const NAME: &'static str = "QueryError";
 const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.RunFunctionRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.RunFunctionRequest".into() }}
-/// Response to a run function request.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RunFunctionResponse {
-    #[prost(message, optional, tag="1")]
-    pub values: ::core::option::Option<ValueBatch>,
-}
-impl ::prost::Name for RunFunctionResponse {
-const NAME: &'static str = "RunFunctionResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.RunFunctionResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.RunFunctionResponse".into() }}
-/// Batch of values.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ValueBatch {
-    #[prost(message, repeated, tag="1")]
-    pub values: ::prost::alloc::vec::Vec<super::super::v1::Value>,
-}
-impl ::prost::Name for ValueBatch {
-const NAME: &'static str = "ValueBatch";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.ValueBatch".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.ValueBatch".into() }}
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.QueryError".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.QueryError".into() }}
 /// Root user credentials.
 #[derive(serde::Deserialize,serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -815,23 +369,6 @@ impl ::prost::Name for AccessMethod {
 const NAME: &'static str = "AccessMethod";
 const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
 fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.AccessMethod".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.AccessMethod".into() }}
-/// Response to a live query.
-#[derive(serde::Deserialize,serde::Serialize)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct LiveResponse {
-    #[prost(message, optional, tag="1")]
-    pub id: ::core::option::Option<super::super::v1::Uuid>,
-    #[prost(enumeration="Action", tag="2")]
-    pub action: i32,
-    #[prost(message, optional, tag="3")]
-    pub record: ::core::option::Option<super::super::v1::Value>,
-    #[prost(message, optional, tag="4")]
-    pub result: ::core::option::Option<super::super::v1::Value>,
-}
-impl ::prost::Name for LiveResponse {
-const NAME: &'static str = "LiveResponse";
-const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
-fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.LiveResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.LiveResponse".into() }}
 /// Variables.
 #[derive(serde::Deserialize,serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -849,9 +386,9 @@ fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.Va
 #[repr(i32)]
 pub enum Action {
     Unspecified = 0,
-    Create = 1,
-    Update = 2,
-    Delete = 3,
+    Created = 1,
+    Updated = 2,
+    Deleted = 3,
     Killed = 4,
 }
 impl Action {
@@ -862,9 +399,9 @@ impl Action {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             Self::Unspecified => "ACTION_UNSPECIFIED",
-            Self::Create => "ACTION_CREATE",
-            Self::Update => "ACTION_UPDATE",
-            Self::Delete => "ACTION_DELETE",
+            Self::Created => "ACTION_CREATED",
+            Self::Updated => "ACTION_UPDATED",
+            Self::Deleted => "ACTION_DELETED",
             Self::Killed => "ACTION_KILLED",
         }
     }
@@ -872,9 +409,9 @@ impl Action {
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "ACTION_UNSPECIFIED" => Some(Self::Unspecified),
-            "ACTION_CREATE" => Some(Self::Create),
-            "ACTION_UPDATE" => Some(Self::Update),
-            "ACTION_DELETE" => Some(Self::Delete),
+            "ACTION_CREATED" => Some(Self::Created),
+            "ACTION_UPDATED" => Some(Self::Updated),
+            "ACTION_DELETED" => Some(Self::Deleted),
             "ACTION_KILLED" => Some(Self::Killed),
             _ => None,
         }

--- a/gen/rust/proto/surrealdb.protocol.rpc.v1.tonic.rs
+++ b/gen/rust/proto/surrealdb.protocol.rpc.v1.tonic.rs
@@ -145,107 +145,6 @@ pub mod surreal_db_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        pub async fn info(
-            &mut self,
-            request: impl tonic::IntoRequest<super::InfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::InfoResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Info",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("surrealdb.protocol.rpc.v1.SurrealDBService", "Info"),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn query(
-            &mut self,
-            request: impl tonic::IntoRequest<super::QueryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::QueryResponse>>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Query",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Query",
-                    ),
-                );
-            self.inner.server_streaming(req, path, codec).await
-        }
-        pub async fn live(
-            &mut self,
-            request: impl tonic::IntoRequest<super::LiveRequest>,
-        ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::LiveResponse>>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Live",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("surrealdb.protocol.rpc.v1.SurrealDBService", "Live"),
-                );
-            self.inner.server_streaming(req, path, codec).await
-        }
-        pub async fn r#use(
-            &mut self,
-            request: impl tonic::IntoRequest<super::UseRequest>,
-        ) -> std::result::Result<tonic::Response<super::UseResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Use",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("surrealdb.protocol.rpc.v1.SurrealDBService", "Use"),
-                );
-            self.inner.unary(req, path, codec).await
-        }
         pub async fn signup(
             &mut self,
             request: impl tonic::IntoRequest<super::SignupRequest>,
@@ -327,11 +226,11 @@ pub mod surreal_db_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        pub async fn invalidate(
+        pub async fn query(
             &mut self,
-            request: impl tonic::IntoRequest<super::InvalidateRequest>,
+            request: impl tonic::IntoRequest<super::QueryRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::InvalidateResponse>,
+            tonic::Response<tonic::codec::Streaming<super::QueryResponse>>,
             tonic::Status,
         > {
             self.inner
@@ -344,303 +243,23 @@ pub mod surreal_db_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Invalidate",
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Query",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
                         "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Invalidate",
+                        "Query",
                     ),
                 );
-            self.inner.unary(req, path, codec).await
+            self.inner.server_streaming(req, path, codec).await
         }
-        pub async fn reset(
+        pub async fn subscribe(
             &mut self,
-            request: impl tonic::IntoRequest<super::ResetRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResetResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Reset",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Reset",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn kill(
-            &mut self,
-            request: impl tonic::IntoRequest<super::KillRequest>,
-        ) -> std::result::Result<tonic::Response<super::KillResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Kill",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("surrealdb.protocol.rpc.v1.SurrealDBService", "Kill"),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn set(
-            &mut self,
-            request: impl tonic::IntoRequest<super::SetRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Set",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("surrealdb.protocol.rpc.v1.SurrealDBService", "Set"),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn unset(
-            &mut self,
-            request: impl tonic::IntoRequest<super::UnsetRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnsetResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Unset",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Unset",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn select(
-            &mut self,
-            request: impl tonic::IntoRequest<super::SelectRequest>,
-        ) -> std::result::Result<tonic::Response<super::SelectResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Select",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Select",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn create(
-            &mut self,
-            request: impl tonic::IntoRequest<super::CreateRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreateResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Create",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Create",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn insert(
-            &mut self,
-            request: impl tonic::IntoRequest<super::InsertRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Insert",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Insert",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn upsert(
-            &mut self,
-            request: impl tonic::IntoRequest<super::UpsertRequest>,
-        ) -> std::result::Result<tonic::Response<super::UpsertResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Upsert",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Upsert",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn update(
-            &mut self,
-            request: impl tonic::IntoRequest<super::UpdateRequest>,
-        ) -> std::result::Result<tonic::Response<super::UpdateResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Update",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Update",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn delete(
-            &mut self,
-            request: impl tonic::IntoRequest<super::DeleteRequest>,
-        ) -> std::result::Result<tonic::Response<super::DeleteResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Delete",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Delete",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn relate(
-            &mut self,
-            request: impl tonic::IntoRequest<super::RelateRequest>,
-        ) -> std::result::Result<tonic::Response<super::RelateResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Relate",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "Relate",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn run_function(
-            &mut self,
-            request: impl tonic::IntoRequest<super::RunFunctionRequest>,
+            request: impl tonic::IntoRequest<super::SubscribeRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::RunFunctionResponse>,
+            tonic::Response<tonic::codec::Streaming<super::SubscribeResponse>>,
             tonic::Status,
         > {
             self.inner
@@ -653,17 +272,17 @@ pub mod surreal_db_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/RunFunction",
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Subscribe",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
                         "surrealdb.protocol.rpc.v1.SurrealDBService",
-                        "RunFunction",
+                        "Subscribe",
                     ),
                 );
-            self.inner.unary(req, path, codec).await
+            self.inner.server_streaming(req, path, codec).await
         }
     }
 }
@@ -688,34 +307,6 @@ pub mod surreal_db_service_server {
             &self,
             request: tonic::Request<super::VersionRequest>,
         ) -> std::result::Result<tonic::Response<super::VersionResponse>, tonic::Status>;
-        async fn info(
-            &self,
-            request: tonic::Request<super::InfoRequest>,
-        ) -> std::result::Result<tonic::Response<super::InfoResponse>, tonic::Status>;
-        /// Server streaming response type for the Query method.
-        type QueryStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::QueryResponse, tonic::Status>,
-            >
-            + std::marker::Send
-            + 'static;
-        async fn query(
-            &self,
-            request: tonic::Request<super::QueryRequest>,
-        ) -> std::result::Result<tonic::Response<Self::QueryStream>, tonic::Status>;
-        /// Server streaming response type for the Live method.
-        type LiveStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::LiveResponse, tonic::Status>,
-            >
-            + std::marker::Send
-            + 'static;
-        async fn live(
-            &self,
-            request: tonic::Request<super::LiveRequest>,
-        ) -> std::result::Result<tonic::Response<Self::LiveStream>, tonic::Status>;
-        async fn r#use(
-            &self,
-            request: tonic::Request<super::UseRequest>,
-        ) -> std::result::Result<tonic::Response<super::UseResponse>, tonic::Status>;
         async fn signup(
             &self,
             request: tonic::Request<super::SignupRequest>,
@@ -731,64 +322,26 @@ pub mod surreal_db_service_server {
             tonic::Response<super::AuthenticateResponse>,
             tonic::Status,
         >;
-        async fn invalidate(
+        /// Server streaming response type for the Query method.
+        type QueryStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::QueryResponse, tonic::Status>,
+            >
+            + std::marker::Send
+            + 'static;
+        async fn query(
             &self,
-            request: tonic::Request<super::InvalidateRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::InvalidateResponse>,
-            tonic::Status,
-        >;
-        async fn reset(
+            request: tonic::Request<super::QueryRequest>,
+        ) -> std::result::Result<tonic::Response<Self::QueryStream>, tonic::Status>;
+        /// Server streaming response type for the Subscribe method.
+        type SubscribeStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::SubscribeResponse, tonic::Status>,
+            >
+            + std::marker::Send
+            + 'static;
+        async fn subscribe(
             &self,
-            request: tonic::Request<super::ResetRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResetResponse>, tonic::Status>;
-        async fn kill(
-            &self,
-            request: tonic::Request<super::KillRequest>,
-        ) -> std::result::Result<tonic::Response<super::KillResponse>, tonic::Status>;
-        async fn set(
-            &self,
-            request: tonic::Request<super::SetRequest>,
-        ) -> std::result::Result<tonic::Response<super::SetResponse>, tonic::Status>;
-        async fn unset(
-            &self,
-            request: tonic::Request<super::UnsetRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnsetResponse>, tonic::Status>;
-        async fn select(
-            &self,
-            request: tonic::Request<super::SelectRequest>,
-        ) -> std::result::Result<tonic::Response<super::SelectResponse>, tonic::Status>;
-        async fn create(
-            &self,
-            request: tonic::Request<super::CreateRequest>,
-        ) -> std::result::Result<tonic::Response<super::CreateResponse>, tonic::Status>;
-        async fn insert(
-            &self,
-            request: tonic::Request<super::InsertRequest>,
-        ) -> std::result::Result<tonic::Response<super::InsertResponse>, tonic::Status>;
-        async fn upsert(
-            &self,
-            request: tonic::Request<super::UpsertRequest>,
-        ) -> std::result::Result<tonic::Response<super::UpsertResponse>, tonic::Status>;
-        async fn update(
-            &self,
-            request: tonic::Request<super::UpdateRequest>,
-        ) -> std::result::Result<tonic::Response<super::UpdateResponse>, tonic::Status>;
-        async fn delete(
-            &self,
-            request: tonic::Request<super::DeleteRequest>,
-        ) -> std::result::Result<tonic::Response<super::DeleteResponse>, tonic::Status>;
-        async fn relate(
-            &self,
-            request: tonic::Request<super::RelateRequest>,
-        ) -> std::result::Result<tonic::Response<super::RelateResponse>, tonic::Status>;
-        async fn run_function(
-            &self,
-            request: tonic::Request<super::RunFunctionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::RunFunctionResponse>,
-            tonic::Status,
-        >;
+            request: tonic::Request<super::SubscribeRequest>,
+        ) -> std::result::Result<tonic::Response<Self::SubscribeStream>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct SurrealDbServiceServer<T> {
@@ -956,186 +509,6 @@ pub mod surreal_db_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Info" => {
-                    #[allow(non_camel_case_types)]
-                    struct InfoSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::InfoRequest> for InfoSvc<T> {
-                        type Response = super::InfoResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::InfoRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::info(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = InfoSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Query" => {
-                    #[allow(non_camel_case_types)]
-                    struct QuerySvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::ServerStreamingService<super::QueryRequest>
-                    for QuerySvc<T> {
-                        type Response = super::QueryResponse;
-                        type ResponseStream = T::QueryStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::QueryRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::query(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = QuerySvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.server_streaming(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Live" => {
-                    #[allow(non_camel_case_types)]
-                    struct LiveSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::ServerStreamingService<super::LiveRequest>
-                    for LiveSvc<T> {
-                        type Response = super::LiveResponse;
-                        type ResponseStream = T::LiveStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::LiveRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::live(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = LiveSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.server_streaming(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Use" => {
-                    #[allow(non_camel_case_types)]
-                    struct UseSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::UseRequest> for UseSvc<T> {
-                        type Response = super::UseResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::UseRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::r#use(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = UseSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
                 "/surrealdb.protocol.rpc.v1.SurrealDBService/Signup" => {
                     #[allow(non_camel_case_types)]
                     struct SignupSvc<T: SurrealDbService>(pub Arc<T>);
@@ -1271,25 +644,26 @@ pub mod surreal_db_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Invalidate" => {
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Query" => {
                     #[allow(non_camel_case_types)]
-                    struct InvalidateSvc<T: SurrealDbService>(pub Arc<T>);
+                    struct QuerySvc<T: SurrealDbService>(pub Arc<T>);
                     impl<
                         T: SurrealDbService,
-                    > tonic::server::UnaryService<super::InvalidateRequest>
-                    for InvalidateSvc<T> {
-                        type Response = super::InvalidateResponse;
+                    > tonic::server::ServerStreamingService<super::QueryRequest>
+                    for QuerySvc<T> {
+                        type Response = super::QueryResponse;
+                        type ResponseStream = T::QueryStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
+                            tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::InvalidateRequest>,
+                            request: tonic::Request<super::QueryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SurrealDbService>::invalidate(&inner, request).await
+                                <T as SurrealDbService>::query(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1300,7 +674,7 @@ pub mod surreal_db_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = InvalidateSvc(inner);
+                        let method = QuerySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -1311,29 +685,31 @@ pub mod surreal_db_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.unary(method, req).await;
+                        let res = grpc.server_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
                 }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Reset" => {
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Subscribe" => {
                     #[allow(non_camel_case_types)]
-                    struct ResetSvc<T: SurrealDbService>(pub Arc<T>);
+                    struct SubscribeSvc<T: SurrealDbService>(pub Arc<T>);
                     impl<
                         T: SurrealDbService,
-                    > tonic::server::UnaryService<super::ResetRequest> for ResetSvc<T> {
-                        type Response = super::ResetResponse;
+                    > tonic::server::ServerStreamingService<super::SubscribeRequest>
+                    for SubscribeSvc<T> {
+                        type Response = super::SubscribeResponse;
+                        type ResponseStream = T::SubscribeStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
+                            tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::ResetRequest>,
+                            request: tonic::Request<super::SubscribeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SurrealDbService>::reset(&inner, request).await
+                                <T as SurrealDbService>::subscribe(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1344,7 +720,7 @@ pub mod surreal_db_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = ResetSvc(inner);
+                        let method = SubscribeSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -1355,499 +731,7 @@ pub mod surreal_db_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Kill" => {
-                    #[allow(non_camel_case_types)]
-                    struct KillSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::KillRequest> for KillSvc<T> {
-                        type Response = super::KillResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::KillRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::kill(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = KillSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Set" => {
-                    #[allow(non_camel_case_types)]
-                    struct SetSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::SetRequest> for SetSvc<T> {
-                        type Response = super::SetResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::SetRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::set(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = SetSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Unset" => {
-                    #[allow(non_camel_case_types)]
-                    struct UnsetSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::UnsetRequest> for UnsetSvc<T> {
-                        type Response = super::UnsetResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::UnsetRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::unset(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = UnsetSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Select" => {
-                    #[allow(non_camel_case_types)]
-                    struct SelectSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::SelectRequest>
-                    for SelectSvc<T> {
-                        type Response = super::SelectResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::SelectRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::select(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = SelectSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Create" => {
-                    #[allow(non_camel_case_types)]
-                    struct CreateSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::CreateRequest>
-                    for CreateSvc<T> {
-                        type Response = super::CreateResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::CreateRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::create(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = CreateSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Insert" => {
-                    #[allow(non_camel_case_types)]
-                    struct InsertSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::InsertRequest>
-                    for InsertSvc<T> {
-                        type Response = super::InsertResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::InsertRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::insert(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = InsertSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Upsert" => {
-                    #[allow(non_camel_case_types)]
-                    struct UpsertSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::UpsertRequest>
-                    for UpsertSvc<T> {
-                        type Response = super::UpsertResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::UpsertRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::upsert(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = UpsertSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Update" => {
-                    #[allow(non_camel_case_types)]
-                    struct UpdateSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::UpdateRequest>
-                    for UpdateSvc<T> {
-                        type Response = super::UpdateResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::UpdateRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::update(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = UpdateSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Delete" => {
-                    #[allow(non_camel_case_types)]
-                    struct DeleteSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::DeleteRequest>
-                    for DeleteSvc<T> {
-                        type Response = super::DeleteResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::DeleteRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::delete(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = DeleteSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/Relate" => {
-                    #[allow(non_camel_case_types)]
-                    struct RelateSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::RelateRequest>
-                    for RelateSvc<T> {
-                        type Response = super::RelateResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::RelateRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::relate(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = RelateSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/surrealdb.protocol.rpc.v1.SurrealDBService/RunFunction" => {
-                    #[allow(non_camel_case_types)]
-                    struct RunFunctionSvc<T: SurrealDbService>(pub Arc<T>);
-                    impl<
-                        T: SurrealDbService,
-                    > tonic::server::UnaryService<super::RunFunctionRequest>
-                    for RunFunctionSvc<T> {
-                        type Response = super::RunFunctionResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::RunFunctionRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as SurrealDbService>::run_function(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = RunFunctionSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
+                        let res = grpc.server_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)

--- a/gen/ts/surrealdb/protocol/rpc/v1/rpc.ts
+++ b/gen/ts/surrealdb/protocol/rpc/v1/rpc.ts
@@ -10,17 +10,16 @@ import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { Duration } from "../../../../google/protobuf/duration";
 import { Timestamp } from "../../../../google/protobuf/timestamp";
-import { Data, Explain, Fetchs, Fields, Output, With } from "../../v1/expr";
-import { Uuid, Value } from "../../v1/value";
+import { RecordId, Uuid, Value } from "../../v1/value";
 
 export const protobufPackage = "surrealdb.protocol.rpc.v1";
 
 /** Action type. */
 export enum Action {
   UNSPECIFIED = 0,
-  CREATE = 1,
-  UPDATE = 2,
-  DELETE = 3,
+  CREATED = 1,
+  UPDATED = 2,
+  DELETED = 3,
   KILLED = 4,
   UNRECOGNIZED = -1,
 }
@@ -31,14 +30,14 @@ export function actionFromJSON(object: any): Action {
     case "ACTION_UNSPECIFIED":
       return Action.UNSPECIFIED;
     case 1:
-    case "ACTION_CREATE":
-      return Action.CREATE;
+    case "ACTION_CREATED":
+      return Action.CREATED;
     case 2:
-    case "ACTION_UPDATE":
-      return Action.UPDATE;
+    case "ACTION_UPDATED":
+      return Action.UPDATED;
     case 3:
-    case "ACTION_DELETE":
-      return Action.DELETE;
+    case "ACTION_DELETED":
+      return Action.DELETED;
     case 4:
     case "ACTION_KILLED":
       return Action.KILLED;
@@ -53,12 +52,12 @@ export function actionToJSON(object: Action): string {
   switch (object) {
     case Action.UNSPECIFIED:
       return "ACTION_UNSPECIFIED";
-    case Action.CREATE:
-      return "ACTION_CREATE";
-    case Action.UPDATE:
-      return "ACTION_UPDATE";
-    case Action.DELETE:
-      return "ACTION_DELETE";
+    case Action.CREATED:
+      return "ACTION_CREATED";
+    case Action.UPDATED:
+      return "ACTION_UPDATED";
+    case Action.DELETED:
+      return "ACTION_DELETED";
     case Action.KILLED:
       return "ACTION_KILLED";
     case Action.UNRECOGNIZED:
@@ -84,26 +83,6 @@ export interface VersionResponse {
   version: string;
 }
 
-/** Request to get information about the database. */
-export interface InfoRequest {
-}
-
-/** Response to an info request. */
-export interface InfoResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to change the current namespace and database. */
-export interface UseRequest {
-  namespace: string;
-  database: string;
-}
-
-/** Response to a use request. */
-export interface UseResponse {
-  values: ValueBatch | undefined;
-}
-
 /** Request to sign up a new user. */
 export interface SignupRequest {
   namespace: string;
@@ -114,7 +93,7 @@ export interface SignupRequest {
 
 /** Response to a signup request. */
 export interface SignupResponse {
-  values: ValueBatch | undefined;
+  value: Value | undefined;
 }
 
 /** Request to sign in a user. */
@@ -124,7 +103,7 @@ export interface SigninRequest {
 
 /** Response to a signin request. */
 export interface SigninResponse {
-  values: ValueBatch | undefined;
+  value: Value | undefined;
 }
 
 /** Request to authenticate a user. */
@@ -134,188 +113,26 @@ export interface AuthenticateRequest {
 
 /** Response to an authenticate request. */
 export interface AuthenticateResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to invalidate a user. */
-export interface InvalidateRequest {
-}
-
-/** Response to an invalidate request. */
-export interface InvalidateResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to reset the database. */
-export interface ResetRequest {
-}
-
-/** Response to a reset request. */
-export interface ResetResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to kill a live query. */
-export interface KillRequest {
-  liveId: string;
-}
-
-/** Response to a kill request. */
-export interface KillResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to issue a live query. */
-export interface LiveRequest {
-  what: Value | undefined;
-  expr: Fields | undefined;
-  cond: Value | undefined;
-}
-
-/** Request to set a value. */
-export interface SetRequest {
-  key: string;
   value: Value | undefined;
 }
 
-/** Response to a set request. */
-export interface SetResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to unset a value. */
-export interface UnsetRequest {
-  key: string;
-}
-
-/** Response to an unset request. */
-export interface UnsetResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to create a new record. */
-export interface CreateRequest {
-  txn: Uuid | undefined;
-  only: boolean;
-  what: Value[];
-  data: Data | undefined;
-  output: Output | undefined;
-  timeout: Duration | undefined;
-  parallel: boolean;
-  version: Value | undefined;
+/** Request to issue a live query. */
+export interface SubscribeRequest {
+  query: string;
   variables: Variables | undefined;
 }
 
-/** Response to a create request. */
-export interface CreateResponse {
-  values: ValueBatch | undefined;
+/** Response to a live query. */
+export interface SubscribeResponse {
+  notification: Notification | undefined;
 }
 
-/** Request to select values from the database. */
-export interface SelectRequest {
-  txn: Uuid | undefined;
-  expr: Fields | undefined;
-  omit: Value | undefined;
-  only: boolean;
-  what: Value[];
-  with: Value | undefined;
-  cond: Value | undefined;
-  split: Value | undefined;
-  group: Value | undefined;
-  order: Value | undefined;
-  start: bigint;
-  limit: bigint;
-  fetch: Fetchs | undefined;
-  version: Value | undefined;
-  timeout: Duration | undefined;
-  parallel: boolean;
-  explain: Explain | undefined;
-  tempfiles: boolean;
-  variables: Variables | undefined;
-}
-
-/** Response to a select request. */
-export interface SelectResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to insert a new record. */
-export interface InsertRequest {
-  txn: Uuid | undefined;
-  into: Value | undefined;
-  data: Data | undefined;
-  ignore: boolean;
-  update: Value | undefined;
-  output: Output | undefined;
-  timeout: Duration | undefined;
-  parallel: boolean;
-  relation: boolean;
-  version: Value | undefined;
-  variables: Variables | undefined;
-}
-
-/** Response to an insert request. */
-export interface InsertResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to upsert a record. */
-export interface UpsertRequest {
-  txn: Uuid | undefined;
-  only: boolean;
-  what: Value[];
-  with: With | undefined;
-  data: Data | undefined;
-  cond: Value | undefined;
-  output: Output | undefined;
-  timeout: Duration | undefined;
-  parallel: boolean;
-  explain: Explain | undefined;
-  variables: Variables | undefined;
-}
-
-/** Response to an upsert request. */
-export interface UpsertResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to update a record. */
-export interface UpdateRequest {
-  txn: Uuid | undefined;
-  only: boolean;
-  what: Value[];
-  with: With | undefined;
-  data: Data | undefined;
-  cond: Value | undefined;
-  output: Output | undefined;
-  timeout: Duration | undefined;
-  parallel: boolean;
-  explain: Explain | undefined;
-  variables: Variables | undefined;
-}
-
-/** Response to an update request. */
-export interface UpdateResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to delete a record. */
-export interface DeleteRequest {
-  txn: Uuid | undefined;
-  only: boolean;
-  what: Value[];
-  with: With | undefined;
-  cond: Value | undefined;
-  output: Output | undefined;
-  timeout: Duration | undefined;
-  parallel: boolean;
-  explain: Explain | undefined;
-  variables: Variables | undefined;
-}
-
-/** Response to a delete request. */
-export interface DeleteResponse {
-  values: ValueBatch | undefined;
+/** A notification from a live query. */
+export interface Notification {
+  liveQueryId: Uuid | undefined;
+  action: Action;
+  recordId: RecordId | undefined;
+  value: Value | undefined;
 }
 
 /** Request to query the database. */
@@ -334,32 +151,45 @@ export interface QueryRequest {
  * value batches may elide the stats.
  *
  * Responses are ordered by query index, then batch index. For example:
- *  QueryResponse(query_index=0, batch_index=0)
- *  QueryResponse(query_index=0, batch_index=1)
- *  QueryResponse(query_index=1, batch_index=0)
- *  QueryResponse(query_index=2, batch_index=0)
- *  QueryResponse(query_index=2, batch_index=1)
- *  QueryResponse(query_index=2, batch_index=2)
- *  QueryResponse(query_index=3, batch_index=0)
- *  QueryResponse(query_index=4, batch_index=0)
+ *  QueryResponse(query_index=0, batch_index=0, stats=None)
+ *  QueryResponse(query_index=0, batch_index=1, stats=Some(..))
+ *  QueryResponse(query_index=1, batch_index=0, stats=Some(..))
+ *  QueryResponse(query_index=2, batch_index=0, stats=None)
+ *  QueryResponse(query_index=2, batch_index=1, stats=None)
+ *  QueryResponse(query_index=2, batch_index=2, stats=Some(..))
+ *  QueryResponse(query_index=3, batch_index=0, stats=Some(..))
+ *  QueryResponse(query_index=4, batch_index=0, stats=Some(..))
  */
 export interface QueryResponse {
   /** The index of the query. */
   queryIndex: number;
   /** The index of the batch within the given query. */
   batchIndex: bigint;
-  /** The query stats. */
+  /**
+   * The query stats.
+   * This is only expected to be present in the last batch of each query.
+   */
   stats:
     | QueryStats
     | undefined;
-  /** The value batch. */
-  values: ValueBatch | undefined;
+  /** The error, if any. */
+  error:
+    | QueryError
+    | undefined;
+  /** A batch of values. */
+  values: Value[];
 }
 
 /** Query statistics. */
 export interface QueryStats {
   /** The number of records returned. -1 if unknown. */
-  numRecords: bigint;
+  recordsReturned: bigint;
+  /** The number of bytes returned. -1 if unknown. */
+  bytesReturned: bigint;
+  /** The number of records scanned. -1 if unknown. */
+  recordsScanned: bigint;
+  /** The number of bytes scanned. -1 if unknown. */
+  bytesScanned: bigint;
   /** The start time of the query. */
   startTime:
     | Date
@@ -368,41 +198,12 @@ export interface QueryStats {
   executionDuration: Duration | undefined;
 }
 
-/** Request to relate two records. */
-export interface RelateRequest {
-  txn: Uuid | undefined;
-  only: boolean;
-  kind: Value | undefined;
-  from: Value | undefined;
-  with: Value | undefined;
-  uniq: boolean;
-  data: Data | undefined;
-  output: Output | undefined;
-  timeout: Duration | undefined;
-  parallel: boolean;
-  variables: Variables | undefined;
-}
-
-/** Response to a relate request. */
-export interface RelateResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Request to run a function. */
-export interface RunFunctionRequest {
-  name: string;
-  version: string;
-  args: Value[];
-}
-
-/** Response to a run function request. */
-export interface RunFunctionResponse {
-  values: ValueBatch | undefined;
-}
-
-/** Batch of values. */
-export interface ValueBatch {
-  values: Value[];
+/** Query error. */
+export interface QueryError {
+  /** The error code. */
+  code: bigint;
+  /** The error message. */
+  message: string;
 }
 
 /** Root user credentials. */
@@ -457,14 +258,6 @@ export interface AccessMethod {
     | { $case: "databaseUser"; databaseUser: DatabaseUserCredentials }
     | { $case: "accessToken"; accessToken: AccessToken }
     | undefined;
-}
-
-/** Response to a live query. */
-export interface LiveResponse {
-  id: Uuid | undefined;
-  action: Action;
-  record: Value | undefined;
-  result: Value | undefined;
 }
 
 /** Variables. */
@@ -664,245 +457,6 @@ export const VersionResponse: MessageFns<VersionResponse> = {
   },
 };
 
-function createBaseInfoRequest(): InfoRequest {
-  return {};
-}
-
-export const InfoRequest: MessageFns<InfoRequest> = {
-  encode(_: InfoRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): InfoRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseInfoRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(_: any): InfoRequest {
-    return {};
-  },
-
-  toJSON(_: InfoRequest): unknown {
-    const obj: any = {};
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<InfoRequest>, I>>(base?: I): InfoRequest {
-    return InfoRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<InfoRequest>, I>>(_: I): InfoRequest {
-    const message = createBaseInfoRequest();
-    return message;
-  },
-};
-
-function createBaseInfoResponse(): InfoResponse {
-  return { values: undefined };
-}
-
-export const InfoResponse: MessageFns<InfoResponse> = {
-  encode(message: InfoResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): InfoResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseInfoResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): InfoResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: InfoResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<InfoResponse>, I>>(base?: I): InfoResponse {
-    return InfoResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<InfoResponse>, I>>(object: I): InfoResponse {
-    const message = createBaseInfoResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseUseRequest(): UseRequest {
-  return { namespace: "", database: "" };
-}
-
-export const UseRequest: MessageFns<UseRequest> = {
-  encode(message: UseRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.namespace !== "") {
-      writer.uint32(10).string(message.namespace);
-    }
-    if (message.database !== "") {
-      writer.uint32(18).string(message.database);
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): UseRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseUseRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.namespace = reader.string();
-          continue;
-        }
-        case 2: {
-          if (tag !== 18) {
-            break;
-          }
-
-          message.database = reader.string();
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): UseRequest {
-    return {
-      namespace: isSet(object.namespace) ? globalThis.String(object.namespace) : "",
-      database: isSet(object.database) ? globalThis.String(object.database) : "",
-    };
-  },
-
-  toJSON(message: UseRequest): unknown {
-    const obj: any = {};
-    if (message.namespace !== "") {
-      obj.namespace = message.namespace;
-    }
-    if (message.database !== "") {
-      obj.database = message.database;
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<UseRequest>, I>>(base?: I): UseRequest {
-    return UseRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<UseRequest>, I>>(object: I): UseRequest {
-    const message = createBaseUseRequest();
-    message.namespace = object.namespace ?? "";
-    message.database = object.database ?? "";
-    return message;
-  },
-};
-
-function createBaseUseResponse(): UseResponse {
-  return { values: undefined };
-}
-
-export const UseResponse: MessageFns<UseResponse> = {
-  encode(message: UseResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): UseResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseUseResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): UseResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: UseResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<UseResponse>, I>>(base?: I): UseResponse {
-    return UseResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<UseResponse>, I>>(object: I): UseResponse {
-    const message = createBaseUseResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
 function createBaseSignupRequest(): SignupRequest {
   return { namespace: "", database: "", accessName: "", variables: undefined };
 }
@@ -1014,13 +568,13 @@ export const SignupRequest: MessageFns<SignupRequest> = {
 };
 
 function createBaseSignupResponse(): SignupResponse {
-  return { values: undefined };
+  return { value: undefined };
 }
 
 export const SignupResponse: MessageFns<SignupResponse> = {
   encode(message: SignupResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
+    if (message.value !== undefined) {
+      Value.encode(message.value, writer.uint32(10).fork()).join();
     }
     return writer;
   },
@@ -1037,7 +591,7 @@ export const SignupResponse: MessageFns<SignupResponse> = {
             break;
           }
 
-          message.values = ValueBatch.decode(reader, reader.uint32());
+          message.value = Value.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -1050,13 +604,13 @@ export const SignupResponse: MessageFns<SignupResponse> = {
   },
 
   fromJSON(object: any): SignupResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
+    return { value: isSet(object.value) ? Value.fromJSON(object.value) : undefined };
   },
 
   toJSON(message: SignupResponse): unknown {
     const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
+    if (message.value !== undefined) {
+      obj.value = Value.toJSON(message.value);
     }
     return obj;
   },
@@ -1066,9 +620,7 @@ export const SignupResponse: MessageFns<SignupResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<SignupResponse>, I>>(object: I): SignupResponse {
     const message = createBaseSignupResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
+    message.value = (object.value !== undefined && object.value !== null) ? Value.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -1134,13 +686,13 @@ export const SigninRequest: MessageFns<SigninRequest> = {
 };
 
 function createBaseSigninResponse(): SigninResponse {
-  return { values: undefined };
+  return { value: undefined };
 }
 
 export const SigninResponse: MessageFns<SigninResponse> = {
   encode(message: SigninResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
+    if (message.value !== undefined) {
+      Value.encode(message.value, writer.uint32(10).fork()).join();
     }
     return writer;
   },
@@ -1157,7 +709,7 @@ export const SigninResponse: MessageFns<SigninResponse> = {
             break;
           }
 
-          message.values = ValueBatch.decode(reader, reader.uint32());
+          message.value = Value.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -1170,13 +722,13 @@ export const SigninResponse: MessageFns<SigninResponse> = {
   },
 
   fromJSON(object: any): SigninResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
+    return { value: isSet(object.value) ? Value.fromJSON(object.value) : undefined };
   },
 
   toJSON(message: SigninResponse): unknown {
     const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
+    if (message.value !== undefined) {
+      obj.value = Value.toJSON(message.value);
     }
     return obj;
   },
@@ -1186,9 +738,7 @@ export const SigninResponse: MessageFns<SigninResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<SigninResponse>, I>>(object: I): SigninResponse {
     const message = createBaseSigninResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
+    message.value = (object.value !== undefined && object.value !== null) ? Value.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -1252,13 +802,13 @@ export const AuthenticateRequest: MessageFns<AuthenticateRequest> = {
 };
 
 function createBaseAuthenticateResponse(): AuthenticateResponse {
-  return { values: undefined };
+  return { value: undefined };
 }
 
 export const AuthenticateResponse: MessageFns<AuthenticateResponse> = {
   encode(message: AuthenticateResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
+    if (message.value !== undefined) {
+      Value.encode(message.value, writer.uint32(10).fork()).join();
     }
     return writer;
   },
@@ -1275,7 +825,7 @@ export const AuthenticateResponse: MessageFns<AuthenticateResponse> = {
             break;
           }
 
-          message.values = ValueBatch.decode(reader, reader.uint32());
+          message.value = Value.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -1288,13 +838,13 @@ export const AuthenticateResponse: MessageFns<AuthenticateResponse> = {
   },
 
   fromJSON(object: any): AuthenticateResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
+    return { value: isSet(object.value) ? Value.fromJSON(object.value) : undefined };
   },
 
   toJSON(message: AuthenticateResponse): unknown {
     const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
+    if (message.value !== undefined) {
+      obj.value = Value.toJSON(message.value);
     }
     return obj;
   },
@@ -1304,72 +854,30 @@ export const AuthenticateResponse: MessageFns<AuthenticateResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<AuthenticateResponse>, I>>(object: I): AuthenticateResponse {
     const message = createBaseAuthenticateResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
+    message.value = (object.value !== undefined && object.value !== null) ? Value.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-function createBaseInvalidateRequest(): InvalidateRequest {
-  return {};
+function createBaseSubscribeRequest(): SubscribeRequest {
+  return { query: "", variables: undefined };
 }
 
-export const InvalidateRequest: MessageFns<InvalidateRequest> = {
-  encode(_: InvalidateRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): InvalidateRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseInvalidateRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
+export const SubscribeRequest: MessageFns<SubscribeRequest> = {
+  encode(message: SubscribeRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.query !== "") {
+      writer.uint32(10).string(message.query);
     }
-    return message;
-  },
-
-  fromJSON(_: any): InvalidateRequest {
-    return {};
-  },
-
-  toJSON(_: InvalidateRequest): unknown {
-    const obj: any = {};
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<InvalidateRequest>, I>>(base?: I): InvalidateRequest {
-    return InvalidateRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<InvalidateRequest>, I>>(_: I): InvalidateRequest {
-    const message = createBaseInvalidateRequest();
-    return message;
-  },
-};
-
-function createBaseInvalidateResponse(): InvalidateResponse {
-  return { values: undefined };
-}
-
-export const InvalidateResponse: MessageFns<InvalidateResponse> = {
-  encode(message: InvalidateResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
+    if (message.variables !== undefined) {
+      Variables.encode(message.variables, writer.uint32(18).fork()).join();
     }
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): InvalidateResponse {
+  decode(input: BinaryReader | Uint8Array, length?: number): SubscribeRequest {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseInvalidateResponse();
+    const message = createBaseSubscribeRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1378,294 +886,7 @@ export const InvalidateResponse: MessageFns<InvalidateResponse> = {
             break;
           }
 
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): InvalidateResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: InvalidateResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<InvalidateResponse>, I>>(base?: I): InvalidateResponse {
-    return InvalidateResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<InvalidateResponse>, I>>(object: I): InvalidateResponse {
-    const message = createBaseInvalidateResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseResetRequest(): ResetRequest {
-  return {};
-}
-
-export const ResetRequest: MessageFns<ResetRequest> = {
-  encode(_: ResetRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): ResetRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseResetRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(_: any): ResetRequest {
-    return {};
-  },
-
-  toJSON(_: ResetRequest): unknown {
-    const obj: any = {};
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<ResetRequest>, I>>(base?: I): ResetRequest {
-    return ResetRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<ResetRequest>, I>>(_: I): ResetRequest {
-    const message = createBaseResetRequest();
-    return message;
-  },
-};
-
-function createBaseResetResponse(): ResetResponse {
-  return { values: undefined };
-}
-
-export const ResetResponse: MessageFns<ResetResponse> = {
-  encode(message: ResetResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): ResetResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseResetResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): ResetResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: ResetResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<ResetResponse>, I>>(base?: I): ResetResponse {
-    return ResetResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<ResetResponse>, I>>(object: I): ResetResponse {
-    const message = createBaseResetResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseKillRequest(): KillRequest {
-  return { liveId: "" };
-}
-
-export const KillRequest: MessageFns<KillRequest> = {
-  encode(message: KillRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.liveId !== "") {
-      writer.uint32(10).string(message.liveId);
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): KillRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseKillRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.liveId = reader.string();
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): KillRequest {
-    return { liveId: isSet(object.liveId) ? globalThis.String(object.liveId) : "" };
-  },
-
-  toJSON(message: KillRequest): unknown {
-    const obj: any = {};
-    if (message.liveId !== "") {
-      obj.liveId = message.liveId;
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<KillRequest>, I>>(base?: I): KillRequest {
-    return KillRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<KillRequest>, I>>(object: I): KillRequest {
-    const message = createBaseKillRequest();
-    message.liveId = object.liveId ?? "";
-    return message;
-  },
-};
-
-function createBaseKillResponse(): KillResponse {
-  return { values: undefined };
-}
-
-export const KillResponse: MessageFns<KillResponse> = {
-  encode(message: KillResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): KillResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseKillResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): KillResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: KillResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<KillResponse>, I>>(base?: I): KillResponse {
-    return KillResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<KillResponse>, I>>(object: I): KillResponse {
-    const message = createBaseKillResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseLiveRequest(): LiveRequest {
-  return { what: undefined, expr: undefined, cond: undefined };
-}
-
-export const LiveRequest: MessageFns<LiveRequest> = {
-  encode(message: LiveRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.what !== undefined) {
-      Value.encode(message.what, writer.uint32(10).fork()).join();
-    }
-    if (message.expr !== undefined) {
-      Fields.encode(message.expr, writer.uint32(18).fork()).join();
-    }
-    if (message.cond !== undefined) {
-      Value.encode(message.cond, writer.uint32(26).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): LiveRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseLiveRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.what = Value.decode(reader, reader.uint32());
+          message.query = reader.string();
           continue;
         }
         case 2: {
@@ -1673,7 +894,151 @@ export const LiveRequest: MessageFns<LiveRequest> = {
             break;
           }
 
-          message.expr = Fields.decode(reader, reader.uint32());
+          message.variables = Variables.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SubscribeRequest {
+    return {
+      query: isSet(object.query) ? globalThis.String(object.query) : "",
+      variables: isSet(object.variables) ? Variables.fromJSON(object.variables) : undefined,
+    };
+  },
+
+  toJSON(message: SubscribeRequest): unknown {
+    const obj: any = {};
+    if (message.query !== "") {
+      obj.query = message.query;
+    }
+    if (message.variables !== undefined) {
+      obj.variables = Variables.toJSON(message.variables);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SubscribeRequest>, I>>(base?: I): SubscribeRequest {
+    return SubscribeRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SubscribeRequest>, I>>(object: I): SubscribeRequest {
+    const message = createBaseSubscribeRequest();
+    message.query = object.query ?? "";
+    message.variables = (object.variables !== undefined && object.variables !== null)
+      ? Variables.fromPartial(object.variables)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseSubscribeResponse(): SubscribeResponse {
+  return { notification: undefined };
+}
+
+export const SubscribeResponse: MessageFns<SubscribeResponse> = {
+  encode(message: SubscribeResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.notification !== undefined) {
+      Notification.encode(message.notification, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SubscribeResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSubscribeResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.notification = Notification.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SubscribeResponse {
+    return { notification: isSet(object.notification) ? Notification.fromJSON(object.notification) : undefined };
+  },
+
+  toJSON(message: SubscribeResponse): unknown {
+    const obj: any = {};
+    if (message.notification !== undefined) {
+      obj.notification = Notification.toJSON(message.notification);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SubscribeResponse>, I>>(base?: I): SubscribeResponse {
+    return SubscribeResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SubscribeResponse>, I>>(object: I): SubscribeResponse {
+    const message = createBaseSubscribeResponse();
+    message.notification = (object.notification !== undefined && object.notification !== null)
+      ? Notification.fromPartial(object.notification)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseNotification(): Notification {
+  return { liveQueryId: undefined, action: 0, recordId: undefined, value: undefined };
+}
+
+export const Notification: MessageFns<Notification> = {
+  encode(message: Notification, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.liveQueryId !== undefined) {
+      Uuid.encode(message.liveQueryId, writer.uint32(10).fork()).join();
+    }
+    if (message.action !== 0) {
+      writer.uint32(16).int32(message.action);
+    }
+    if (message.recordId !== undefined) {
+      RecordId.encode(message.recordId, writer.uint32(26).fork()).join();
+    }
+    if (message.value !== undefined) {
+      Value.encode(message.value, writer.uint32(34).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): Notification {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseNotification();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.liveQueryId = Uuid.decode(reader, reader.uint32());
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.action = reader.int32() as any;
           continue;
         }
         case 3: {
@@ -1681,84 +1046,11 @@ export const LiveRequest: MessageFns<LiveRequest> = {
             break;
           }
 
-          message.cond = Value.decode(reader, reader.uint32());
+          message.recordId = RecordId.decode(reader, reader.uint32());
           continue;
         }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): LiveRequest {
-    return {
-      what: isSet(object.what) ? Value.fromJSON(object.what) : undefined,
-      expr: isSet(object.expr) ? Fields.fromJSON(object.expr) : undefined,
-      cond: isSet(object.cond) ? Value.fromJSON(object.cond) : undefined,
-    };
-  },
-
-  toJSON(message: LiveRequest): unknown {
-    const obj: any = {};
-    if (message.what !== undefined) {
-      obj.what = Value.toJSON(message.what);
-    }
-    if (message.expr !== undefined) {
-      obj.expr = Fields.toJSON(message.expr);
-    }
-    if (message.cond !== undefined) {
-      obj.cond = Value.toJSON(message.cond);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<LiveRequest>, I>>(base?: I): LiveRequest {
-    return LiveRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<LiveRequest>, I>>(object: I): LiveRequest {
-    const message = createBaseLiveRequest();
-    message.what = (object.what !== undefined && object.what !== null) ? Value.fromPartial(object.what) : undefined;
-    message.expr = (object.expr !== undefined && object.expr !== null) ? Fields.fromPartial(object.expr) : undefined;
-    message.cond = (object.cond !== undefined && object.cond !== null) ? Value.fromPartial(object.cond) : undefined;
-    return message;
-  },
-};
-
-function createBaseSetRequest(): SetRequest {
-  return { key: "", value: undefined };
-}
-
-export const SetRequest: MessageFns<SetRequest> = {
-  encode(message: SetRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.key !== "") {
-      writer.uint32(10).string(message.key);
-    }
-    if (message.value !== undefined) {
-      Value.encode(message.value, writer.uint32(18).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): SetRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseSetRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.key = reader.string();
-          continue;
-        }
-        case 2: {
-          if (tag !== 18) {
+        case 4: {
+          if (tag !== 34) {
             break;
           }
 
@@ -1774,17 +1066,25 @@ export const SetRequest: MessageFns<SetRequest> = {
     return message;
   },
 
-  fromJSON(object: any): SetRequest {
+  fromJSON(object: any): Notification {
     return {
-      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      liveQueryId: isSet(object.liveQueryId) ? Uuid.fromJSON(object.liveQueryId) : undefined,
+      action: isSet(object.action) ? actionFromJSON(object.action) : 0,
+      recordId: isSet(object.recordId) ? RecordId.fromJSON(object.recordId) : undefined,
       value: isSet(object.value) ? Value.fromJSON(object.value) : undefined,
     };
   },
 
-  toJSON(message: SetRequest): unknown {
+  toJSON(message: Notification): unknown {
     const obj: any = {};
-    if (message.key !== "") {
-      obj.key = message.key;
+    if (message.liveQueryId !== undefined) {
+      obj.liveQueryId = Uuid.toJSON(message.liveQueryId);
+    }
+    if (message.action !== 0) {
+      obj.action = actionToJSON(message.action);
+    }
+    if (message.recordId !== undefined) {
+      obj.recordId = RecordId.toJSON(message.recordId);
     }
     if (message.value !== undefined) {
       obj.value = Value.toJSON(message.value);
@@ -1792,2086 +1092,19 @@ export const SetRequest: MessageFns<SetRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<SetRequest>, I>>(base?: I): SetRequest {
-    return SetRequest.fromPartial(base ?? ({} as any));
+  create<I extends Exact<DeepPartial<Notification>, I>>(base?: I): Notification {
+    return Notification.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<SetRequest>, I>>(object: I): SetRequest {
-    const message = createBaseSetRequest();
-    message.key = object.key ?? "";
+  fromPartial<I extends Exact<DeepPartial<Notification>, I>>(object: I): Notification {
+    const message = createBaseNotification();
+    message.liveQueryId = (object.liveQueryId !== undefined && object.liveQueryId !== null)
+      ? Uuid.fromPartial(object.liveQueryId)
+      : undefined;
+    message.action = object.action ?? 0;
+    message.recordId = (object.recordId !== undefined && object.recordId !== null)
+      ? RecordId.fromPartial(object.recordId)
+      : undefined;
     message.value = (object.value !== undefined && object.value !== null) ? Value.fromPartial(object.value) : undefined;
-    return message;
-  },
-};
-
-function createBaseSetResponse(): SetResponse {
-  return { values: undefined };
-}
-
-export const SetResponse: MessageFns<SetResponse> = {
-  encode(message: SetResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): SetResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseSetResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): SetResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: SetResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<SetResponse>, I>>(base?: I): SetResponse {
-    return SetResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<SetResponse>, I>>(object: I): SetResponse {
-    const message = createBaseSetResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseUnsetRequest(): UnsetRequest {
-  return { key: "" };
-}
-
-export const UnsetRequest: MessageFns<UnsetRequest> = {
-  encode(message: UnsetRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.key !== "") {
-      writer.uint32(10).string(message.key);
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): UnsetRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseUnsetRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.key = reader.string();
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): UnsetRequest {
-    return { key: isSet(object.key) ? globalThis.String(object.key) : "" };
-  },
-
-  toJSON(message: UnsetRequest): unknown {
-    const obj: any = {};
-    if (message.key !== "") {
-      obj.key = message.key;
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<UnsetRequest>, I>>(base?: I): UnsetRequest {
-    return UnsetRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<UnsetRequest>, I>>(object: I): UnsetRequest {
-    const message = createBaseUnsetRequest();
-    message.key = object.key ?? "";
-    return message;
-  },
-};
-
-function createBaseUnsetResponse(): UnsetResponse {
-  return { values: undefined };
-}
-
-export const UnsetResponse: MessageFns<UnsetResponse> = {
-  encode(message: UnsetResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): UnsetResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseUnsetResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): UnsetResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: UnsetResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<UnsetResponse>, I>>(base?: I): UnsetResponse {
-    return UnsetResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<UnsetResponse>, I>>(object: I): UnsetResponse {
-    const message = createBaseUnsetResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseCreateRequest(): CreateRequest {
-  return {
-    txn: undefined,
-    only: false,
-    what: [],
-    data: undefined,
-    output: undefined,
-    timeout: undefined,
-    parallel: false,
-    version: undefined,
-    variables: undefined,
-  };
-}
-
-export const CreateRequest: MessageFns<CreateRequest> = {
-  encode(message: CreateRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.txn !== undefined) {
-      Uuid.encode(message.txn, writer.uint32(10).fork()).join();
-    }
-    if (message.only !== false) {
-      writer.uint32(16).bool(message.only);
-    }
-    for (const v of message.what) {
-      Value.encode(v!, writer.uint32(26).fork()).join();
-    }
-    if (message.data !== undefined) {
-      Data.encode(message.data, writer.uint32(34).fork()).join();
-    }
-    if (message.output !== undefined) {
-      Output.encode(message.output, writer.uint32(42).fork()).join();
-    }
-    if (message.timeout !== undefined) {
-      Duration.encode(message.timeout, writer.uint32(50).fork()).join();
-    }
-    if (message.parallel !== false) {
-      writer.uint32(56).bool(message.parallel);
-    }
-    if (message.version !== undefined) {
-      Value.encode(message.version, writer.uint32(66).fork()).join();
-    }
-    if (message.variables !== undefined) {
-      Variables.encode(message.variables, writer.uint32(74).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): CreateRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseCreateRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.txn = Uuid.decode(reader, reader.uint32());
-          continue;
-        }
-        case 2: {
-          if (tag !== 16) {
-            break;
-          }
-
-          message.only = reader.bool();
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.what.push(Value.decode(reader, reader.uint32()));
-          continue;
-        }
-        case 4: {
-          if (tag !== 34) {
-            break;
-          }
-
-          message.data = Data.decode(reader, reader.uint32());
-          continue;
-        }
-        case 5: {
-          if (tag !== 42) {
-            break;
-          }
-
-          message.output = Output.decode(reader, reader.uint32());
-          continue;
-        }
-        case 6: {
-          if (tag !== 50) {
-            break;
-          }
-
-          message.timeout = Duration.decode(reader, reader.uint32());
-          continue;
-        }
-        case 7: {
-          if (tag !== 56) {
-            break;
-          }
-
-          message.parallel = reader.bool();
-          continue;
-        }
-        case 8: {
-          if (tag !== 66) {
-            break;
-          }
-
-          message.version = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 9: {
-          if (tag !== 74) {
-            break;
-          }
-
-          message.variables = Variables.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): CreateRequest {
-    return {
-      txn: isSet(object.txn) ? Uuid.fromJSON(object.txn) : undefined,
-      only: isSet(object.only) ? globalThis.Boolean(object.only) : false,
-      what: globalThis.Array.isArray(object?.what) ? object.what.map((e: any) => Value.fromJSON(e)) : [],
-      data: isSet(object.data) ? Data.fromJSON(object.data) : undefined,
-      output: isSet(object.output) ? Output.fromJSON(object.output) : undefined,
-      timeout: isSet(object.timeout) ? Duration.fromJSON(object.timeout) : undefined,
-      parallel: isSet(object.parallel) ? globalThis.Boolean(object.parallel) : false,
-      version: isSet(object.version) ? Value.fromJSON(object.version) : undefined,
-      variables: isSet(object.variables) ? Variables.fromJSON(object.variables) : undefined,
-    };
-  },
-
-  toJSON(message: CreateRequest): unknown {
-    const obj: any = {};
-    if (message.txn !== undefined) {
-      obj.txn = Uuid.toJSON(message.txn);
-    }
-    if (message.only !== false) {
-      obj.only = message.only;
-    }
-    if (message.what?.length) {
-      obj.what = message.what.map((e) => Value.toJSON(e));
-    }
-    if (message.data !== undefined) {
-      obj.data = Data.toJSON(message.data);
-    }
-    if (message.output !== undefined) {
-      obj.output = Output.toJSON(message.output);
-    }
-    if (message.timeout !== undefined) {
-      obj.timeout = Duration.toJSON(message.timeout);
-    }
-    if (message.parallel !== false) {
-      obj.parallel = message.parallel;
-    }
-    if (message.version !== undefined) {
-      obj.version = Value.toJSON(message.version);
-    }
-    if (message.variables !== undefined) {
-      obj.variables = Variables.toJSON(message.variables);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<CreateRequest>, I>>(base?: I): CreateRequest {
-    return CreateRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<CreateRequest>, I>>(object: I): CreateRequest {
-    const message = createBaseCreateRequest();
-    message.txn = (object.txn !== undefined && object.txn !== null) ? Uuid.fromPartial(object.txn) : undefined;
-    message.only = object.only ?? false;
-    message.what = object.what?.map((e) => Value.fromPartial(e)) || [];
-    message.data = (object.data !== undefined && object.data !== null) ? Data.fromPartial(object.data) : undefined;
-    message.output = (object.output !== undefined && object.output !== null)
-      ? Output.fromPartial(object.output)
-      : undefined;
-    message.timeout = (object.timeout !== undefined && object.timeout !== null)
-      ? Duration.fromPartial(object.timeout)
-      : undefined;
-    message.parallel = object.parallel ?? false;
-    message.version = (object.version !== undefined && object.version !== null)
-      ? Value.fromPartial(object.version)
-      : undefined;
-    message.variables = (object.variables !== undefined && object.variables !== null)
-      ? Variables.fromPartial(object.variables)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseCreateResponse(): CreateResponse {
-  return { values: undefined };
-}
-
-export const CreateResponse: MessageFns<CreateResponse> = {
-  encode(message: CreateResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): CreateResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseCreateResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): CreateResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: CreateResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<CreateResponse>, I>>(base?: I): CreateResponse {
-    return CreateResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<CreateResponse>, I>>(object: I): CreateResponse {
-    const message = createBaseCreateResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseSelectRequest(): SelectRequest {
-  return {
-    txn: undefined,
-    expr: undefined,
-    omit: undefined,
-    only: false,
-    what: [],
-    with: undefined,
-    cond: undefined,
-    split: undefined,
-    group: undefined,
-    order: undefined,
-    start: 0n,
-    limit: 0n,
-    fetch: undefined,
-    version: undefined,
-    timeout: undefined,
-    parallel: false,
-    explain: undefined,
-    tempfiles: false,
-    variables: undefined,
-  };
-}
-
-export const SelectRequest: MessageFns<SelectRequest> = {
-  encode(message: SelectRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.txn !== undefined) {
-      Uuid.encode(message.txn, writer.uint32(10).fork()).join();
-    }
-    if (message.expr !== undefined) {
-      Fields.encode(message.expr, writer.uint32(18).fork()).join();
-    }
-    if (message.omit !== undefined) {
-      Value.encode(message.omit, writer.uint32(26).fork()).join();
-    }
-    if (message.only !== false) {
-      writer.uint32(32).bool(message.only);
-    }
-    for (const v of message.what) {
-      Value.encode(v!, writer.uint32(42).fork()).join();
-    }
-    if (message.with !== undefined) {
-      Value.encode(message.with, writer.uint32(50).fork()).join();
-    }
-    if (message.cond !== undefined) {
-      Value.encode(message.cond, writer.uint32(58).fork()).join();
-    }
-    if (message.split !== undefined) {
-      Value.encode(message.split, writer.uint32(66).fork()).join();
-    }
-    if (message.group !== undefined) {
-      Value.encode(message.group, writer.uint32(74).fork()).join();
-    }
-    if (message.order !== undefined) {
-      Value.encode(message.order, writer.uint32(82).fork()).join();
-    }
-    if (message.start !== 0n) {
-      if (BigInt.asIntN(64, message.start) !== message.start) {
-        throw new globalThis.Error("value provided for field message.start of type int64 too large");
-      }
-      writer.uint32(88).int64(message.start);
-    }
-    if (message.limit !== 0n) {
-      if (BigInt.asIntN(64, message.limit) !== message.limit) {
-        throw new globalThis.Error("value provided for field message.limit of type int64 too large");
-      }
-      writer.uint32(96).int64(message.limit);
-    }
-    if (message.fetch !== undefined) {
-      Fetchs.encode(message.fetch, writer.uint32(106).fork()).join();
-    }
-    if (message.version !== undefined) {
-      Value.encode(message.version, writer.uint32(114).fork()).join();
-    }
-    if (message.timeout !== undefined) {
-      Duration.encode(message.timeout, writer.uint32(122).fork()).join();
-    }
-    if (message.parallel !== false) {
-      writer.uint32(128).bool(message.parallel);
-    }
-    if (message.explain !== undefined) {
-      Explain.encode(message.explain, writer.uint32(138).fork()).join();
-    }
-    if (message.tempfiles !== false) {
-      writer.uint32(144).bool(message.tempfiles);
-    }
-    if (message.variables !== undefined) {
-      Variables.encode(message.variables, writer.uint32(154).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): SelectRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseSelectRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.txn = Uuid.decode(reader, reader.uint32());
-          continue;
-        }
-        case 2: {
-          if (tag !== 18) {
-            break;
-          }
-
-          message.expr = Fields.decode(reader, reader.uint32());
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.omit = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 4: {
-          if (tag !== 32) {
-            break;
-          }
-
-          message.only = reader.bool();
-          continue;
-        }
-        case 5: {
-          if (tag !== 42) {
-            break;
-          }
-
-          message.what.push(Value.decode(reader, reader.uint32()));
-          continue;
-        }
-        case 6: {
-          if (tag !== 50) {
-            break;
-          }
-
-          message.with = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 7: {
-          if (tag !== 58) {
-            break;
-          }
-
-          message.cond = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 8: {
-          if (tag !== 66) {
-            break;
-          }
-
-          message.split = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 9: {
-          if (tag !== 74) {
-            break;
-          }
-
-          message.group = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 10: {
-          if (tag !== 82) {
-            break;
-          }
-
-          message.order = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 11: {
-          if (tag !== 88) {
-            break;
-          }
-
-          message.start = reader.int64() as bigint;
-          continue;
-        }
-        case 12: {
-          if (tag !== 96) {
-            break;
-          }
-
-          message.limit = reader.int64() as bigint;
-          continue;
-        }
-        case 13: {
-          if (tag !== 106) {
-            break;
-          }
-
-          message.fetch = Fetchs.decode(reader, reader.uint32());
-          continue;
-        }
-        case 14: {
-          if (tag !== 114) {
-            break;
-          }
-
-          message.version = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 15: {
-          if (tag !== 122) {
-            break;
-          }
-
-          message.timeout = Duration.decode(reader, reader.uint32());
-          continue;
-        }
-        case 16: {
-          if (tag !== 128) {
-            break;
-          }
-
-          message.parallel = reader.bool();
-          continue;
-        }
-        case 17: {
-          if (tag !== 138) {
-            break;
-          }
-
-          message.explain = Explain.decode(reader, reader.uint32());
-          continue;
-        }
-        case 18: {
-          if (tag !== 144) {
-            break;
-          }
-
-          message.tempfiles = reader.bool();
-          continue;
-        }
-        case 19: {
-          if (tag !== 154) {
-            break;
-          }
-
-          message.variables = Variables.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): SelectRequest {
-    return {
-      txn: isSet(object.txn) ? Uuid.fromJSON(object.txn) : undefined,
-      expr: isSet(object.expr) ? Fields.fromJSON(object.expr) : undefined,
-      omit: isSet(object.omit) ? Value.fromJSON(object.omit) : undefined,
-      only: isSet(object.only) ? globalThis.Boolean(object.only) : false,
-      what: globalThis.Array.isArray(object?.what) ? object.what.map((e: any) => Value.fromJSON(e)) : [],
-      with: isSet(object.with) ? Value.fromJSON(object.with) : undefined,
-      cond: isSet(object.cond) ? Value.fromJSON(object.cond) : undefined,
-      split: isSet(object.split) ? Value.fromJSON(object.split) : undefined,
-      group: isSet(object.group) ? Value.fromJSON(object.group) : undefined,
-      order: isSet(object.order) ? Value.fromJSON(object.order) : undefined,
-      start: isSet(object.start) ? BigInt(object.start) : 0n,
-      limit: isSet(object.limit) ? BigInt(object.limit) : 0n,
-      fetch: isSet(object.fetch) ? Fetchs.fromJSON(object.fetch) : undefined,
-      version: isSet(object.version) ? Value.fromJSON(object.version) : undefined,
-      timeout: isSet(object.timeout) ? Duration.fromJSON(object.timeout) : undefined,
-      parallel: isSet(object.parallel) ? globalThis.Boolean(object.parallel) : false,
-      explain: isSet(object.explain) ? Explain.fromJSON(object.explain) : undefined,
-      tempfiles: isSet(object.tempfiles) ? globalThis.Boolean(object.tempfiles) : false,
-      variables: isSet(object.variables) ? Variables.fromJSON(object.variables) : undefined,
-    };
-  },
-
-  toJSON(message: SelectRequest): unknown {
-    const obj: any = {};
-    if (message.txn !== undefined) {
-      obj.txn = Uuid.toJSON(message.txn);
-    }
-    if (message.expr !== undefined) {
-      obj.expr = Fields.toJSON(message.expr);
-    }
-    if (message.omit !== undefined) {
-      obj.omit = Value.toJSON(message.omit);
-    }
-    if (message.only !== false) {
-      obj.only = message.only;
-    }
-    if (message.what?.length) {
-      obj.what = message.what.map((e) => Value.toJSON(e));
-    }
-    if (message.with !== undefined) {
-      obj.with = Value.toJSON(message.with);
-    }
-    if (message.cond !== undefined) {
-      obj.cond = Value.toJSON(message.cond);
-    }
-    if (message.split !== undefined) {
-      obj.split = Value.toJSON(message.split);
-    }
-    if (message.group !== undefined) {
-      obj.group = Value.toJSON(message.group);
-    }
-    if (message.order !== undefined) {
-      obj.order = Value.toJSON(message.order);
-    }
-    if (message.start !== 0n) {
-      obj.start = message.start.toString();
-    }
-    if (message.limit !== 0n) {
-      obj.limit = message.limit.toString();
-    }
-    if (message.fetch !== undefined) {
-      obj.fetch = Fetchs.toJSON(message.fetch);
-    }
-    if (message.version !== undefined) {
-      obj.version = Value.toJSON(message.version);
-    }
-    if (message.timeout !== undefined) {
-      obj.timeout = Duration.toJSON(message.timeout);
-    }
-    if (message.parallel !== false) {
-      obj.parallel = message.parallel;
-    }
-    if (message.explain !== undefined) {
-      obj.explain = Explain.toJSON(message.explain);
-    }
-    if (message.tempfiles !== false) {
-      obj.tempfiles = message.tempfiles;
-    }
-    if (message.variables !== undefined) {
-      obj.variables = Variables.toJSON(message.variables);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<SelectRequest>, I>>(base?: I): SelectRequest {
-    return SelectRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<SelectRequest>, I>>(object: I): SelectRequest {
-    const message = createBaseSelectRequest();
-    message.txn = (object.txn !== undefined && object.txn !== null) ? Uuid.fromPartial(object.txn) : undefined;
-    message.expr = (object.expr !== undefined && object.expr !== null) ? Fields.fromPartial(object.expr) : undefined;
-    message.omit = (object.omit !== undefined && object.omit !== null) ? Value.fromPartial(object.omit) : undefined;
-    message.only = object.only ?? false;
-    message.what = object.what?.map((e) => Value.fromPartial(e)) || [];
-    message.with = (object.with !== undefined && object.with !== null) ? Value.fromPartial(object.with) : undefined;
-    message.cond = (object.cond !== undefined && object.cond !== null) ? Value.fromPartial(object.cond) : undefined;
-    message.split = (object.split !== undefined && object.split !== null) ? Value.fromPartial(object.split) : undefined;
-    message.group = (object.group !== undefined && object.group !== null) ? Value.fromPartial(object.group) : undefined;
-    message.order = (object.order !== undefined && object.order !== null) ? Value.fromPartial(object.order) : undefined;
-    message.start = object.start ?? 0n;
-    message.limit = object.limit ?? 0n;
-    message.fetch = (object.fetch !== undefined && object.fetch !== null)
-      ? Fetchs.fromPartial(object.fetch)
-      : undefined;
-    message.version = (object.version !== undefined && object.version !== null)
-      ? Value.fromPartial(object.version)
-      : undefined;
-    message.timeout = (object.timeout !== undefined && object.timeout !== null)
-      ? Duration.fromPartial(object.timeout)
-      : undefined;
-    message.parallel = object.parallel ?? false;
-    message.explain = (object.explain !== undefined && object.explain !== null)
-      ? Explain.fromPartial(object.explain)
-      : undefined;
-    message.tempfiles = object.tempfiles ?? false;
-    message.variables = (object.variables !== undefined && object.variables !== null)
-      ? Variables.fromPartial(object.variables)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseSelectResponse(): SelectResponse {
-  return { values: undefined };
-}
-
-export const SelectResponse: MessageFns<SelectResponse> = {
-  encode(message: SelectResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): SelectResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseSelectResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): SelectResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: SelectResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<SelectResponse>, I>>(base?: I): SelectResponse {
-    return SelectResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<SelectResponse>, I>>(object: I): SelectResponse {
-    const message = createBaseSelectResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseInsertRequest(): InsertRequest {
-  return {
-    txn: undefined,
-    into: undefined,
-    data: undefined,
-    ignore: false,
-    update: undefined,
-    output: undefined,
-    timeout: undefined,
-    parallel: false,
-    relation: false,
-    version: undefined,
-    variables: undefined,
-  };
-}
-
-export const InsertRequest: MessageFns<InsertRequest> = {
-  encode(message: InsertRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.txn !== undefined) {
-      Uuid.encode(message.txn, writer.uint32(10).fork()).join();
-    }
-    if (message.into !== undefined) {
-      Value.encode(message.into, writer.uint32(18).fork()).join();
-    }
-    if (message.data !== undefined) {
-      Data.encode(message.data, writer.uint32(26).fork()).join();
-    }
-    if (message.ignore !== false) {
-      writer.uint32(32).bool(message.ignore);
-    }
-    if (message.update !== undefined) {
-      Value.encode(message.update, writer.uint32(42).fork()).join();
-    }
-    if (message.output !== undefined) {
-      Output.encode(message.output, writer.uint32(50).fork()).join();
-    }
-    if (message.timeout !== undefined) {
-      Duration.encode(message.timeout, writer.uint32(58).fork()).join();
-    }
-    if (message.parallel !== false) {
-      writer.uint32(64).bool(message.parallel);
-    }
-    if (message.relation !== false) {
-      writer.uint32(72).bool(message.relation);
-    }
-    if (message.version !== undefined) {
-      Value.encode(message.version, writer.uint32(82).fork()).join();
-    }
-    if (message.variables !== undefined) {
-      Variables.encode(message.variables, writer.uint32(90).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): InsertRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseInsertRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.txn = Uuid.decode(reader, reader.uint32());
-          continue;
-        }
-        case 2: {
-          if (tag !== 18) {
-            break;
-          }
-
-          message.into = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.data = Data.decode(reader, reader.uint32());
-          continue;
-        }
-        case 4: {
-          if (tag !== 32) {
-            break;
-          }
-
-          message.ignore = reader.bool();
-          continue;
-        }
-        case 5: {
-          if (tag !== 42) {
-            break;
-          }
-
-          message.update = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 6: {
-          if (tag !== 50) {
-            break;
-          }
-
-          message.output = Output.decode(reader, reader.uint32());
-          continue;
-        }
-        case 7: {
-          if (tag !== 58) {
-            break;
-          }
-
-          message.timeout = Duration.decode(reader, reader.uint32());
-          continue;
-        }
-        case 8: {
-          if (tag !== 64) {
-            break;
-          }
-
-          message.parallel = reader.bool();
-          continue;
-        }
-        case 9: {
-          if (tag !== 72) {
-            break;
-          }
-
-          message.relation = reader.bool();
-          continue;
-        }
-        case 10: {
-          if (tag !== 82) {
-            break;
-          }
-
-          message.version = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 11: {
-          if (tag !== 90) {
-            break;
-          }
-
-          message.variables = Variables.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): InsertRequest {
-    return {
-      txn: isSet(object.txn) ? Uuid.fromJSON(object.txn) : undefined,
-      into: isSet(object.into) ? Value.fromJSON(object.into) : undefined,
-      data: isSet(object.data) ? Data.fromJSON(object.data) : undefined,
-      ignore: isSet(object.ignore) ? globalThis.Boolean(object.ignore) : false,
-      update: isSet(object.update) ? Value.fromJSON(object.update) : undefined,
-      output: isSet(object.output) ? Output.fromJSON(object.output) : undefined,
-      timeout: isSet(object.timeout) ? Duration.fromJSON(object.timeout) : undefined,
-      parallel: isSet(object.parallel) ? globalThis.Boolean(object.parallel) : false,
-      relation: isSet(object.relation) ? globalThis.Boolean(object.relation) : false,
-      version: isSet(object.version) ? Value.fromJSON(object.version) : undefined,
-      variables: isSet(object.variables) ? Variables.fromJSON(object.variables) : undefined,
-    };
-  },
-
-  toJSON(message: InsertRequest): unknown {
-    const obj: any = {};
-    if (message.txn !== undefined) {
-      obj.txn = Uuid.toJSON(message.txn);
-    }
-    if (message.into !== undefined) {
-      obj.into = Value.toJSON(message.into);
-    }
-    if (message.data !== undefined) {
-      obj.data = Data.toJSON(message.data);
-    }
-    if (message.ignore !== false) {
-      obj.ignore = message.ignore;
-    }
-    if (message.update !== undefined) {
-      obj.update = Value.toJSON(message.update);
-    }
-    if (message.output !== undefined) {
-      obj.output = Output.toJSON(message.output);
-    }
-    if (message.timeout !== undefined) {
-      obj.timeout = Duration.toJSON(message.timeout);
-    }
-    if (message.parallel !== false) {
-      obj.parallel = message.parallel;
-    }
-    if (message.relation !== false) {
-      obj.relation = message.relation;
-    }
-    if (message.version !== undefined) {
-      obj.version = Value.toJSON(message.version);
-    }
-    if (message.variables !== undefined) {
-      obj.variables = Variables.toJSON(message.variables);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<InsertRequest>, I>>(base?: I): InsertRequest {
-    return InsertRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<InsertRequest>, I>>(object: I): InsertRequest {
-    const message = createBaseInsertRequest();
-    message.txn = (object.txn !== undefined && object.txn !== null) ? Uuid.fromPartial(object.txn) : undefined;
-    message.into = (object.into !== undefined && object.into !== null) ? Value.fromPartial(object.into) : undefined;
-    message.data = (object.data !== undefined && object.data !== null) ? Data.fromPartial(object.data) : undefined;
-    message.ignore = object.ignore ?? false;
-    message.update = (object.update !== undefined && object.update !== null)
-      ? Value.fromPartial(object.update)
-      : undefined;
-    message.output = (object.output !== undefined && object.output !== null)
-      ? Output.fromPartial(object.output)
-      : undefined;
-    message.timeout = (object.timeout !== undefined && object.timeout !== null)
-      ? Duration.fromPartial(object.timeout)
-      : undefined;
-    message.parallel = object.parallel ?? false;
-    message.relation = object.relation ?? false;
-    message.version = (object.version !== undefined && object.version !== null)
-      ? Value.fromPartial(object.version)
-      : undefined;
-    message.variables = (object.variables !== undefined && object.variables !== null)
-      ? Variables.fromPartial(object.variables)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseInsertResponse(): InsertResponse {
-  return { values: undefined };
-}
-
-export const InsertResponse: MessageFns<InsertResponse> = {
-  encode(message: InsertResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): InsertResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseInsertResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): InsertResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: InsertResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<InsertResponse>, I>>(base?: I): InsertResponse {
-    return InsertResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<InsertResponse>, I>>(object: I): InsertResponse {
-    const message = createBaseInsertResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseUpsertRequest(): UpsertRequest {
-  return {
-    txn: undefined,
-    only: false,
-    what: [],
-    with: undefined,
-    data: undefined,
-    cond: undefined,
-    output: undefined,
-    timeout: undefined,
-    parallel: false,
-    explain: undefined,
-    variables: undefined,
-  };
-}
-
-export const UpsertRequest: MessageFns<UpsertRequest> = {
-  encode(message: UpsertRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.txn !== undefined) {
-      Uuid.encode(message.txn, writer.uint32(10).fork()).join();
-    }
-    if (message.only !== false) {
-      writer.uint32(16).bool(message.only);
-    }
-    for (const v of message.what) {
-      Value.encode(v!, writer.uint32(26).fork()).join();
-    }
-    if (message.with !== undefined) {
-      With.encode(message.with, writer.uint32(34).fork()).join();
-    }
-    if (message.data !== undefined) {
-      Data.encode(message.data, writer.uint32(42).fork()).join();
-    }
-    if (message.cond !== undefined) {
-      Value.encode(message.cond, writer.uint32(50).fork()).join();
-    }
-    if (message.output !== undefined) {
-      Output.encode(message.output, writer.uint32(58).fork()).join();
-    }
-    if (message.timeout !== undefined) {
-      Duration.encode(message.timeout, writer.uint32(66).fork()).join();
-    }
-    if (message.parallel !== false) {
-      writer.uint32(72).bool(message.parallel);
-    }
-    if (message.explain !== undefined) {
-      Explain.encode(message.explain, writer.uint32(82).fork()).join();
-    }
-    if (message.variables !== undefined) {
-      Variables.encode(message.variables, writer.uint32(90).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): UpsertRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseUpsertRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.txn = Uuid.decode(reader, reader.uint32());
-          continue;
-        }
-        case 2: {
-          if (tag !== 16) {
-            break;
-          }
-
-          message.only = reader.bool();
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.what.push(Value.decode(reader, reader.uint32()));
-          continue;
-        }
-        case 4: {
-          if (tag !== 34) {
-            break;
-          }
-
-          message.with = With.decode(reader, reader.uint32());
-          continue;
-        }
-        case 5: {
-          if (tag !== 42) {
-            break;
-          }
-
-          message.data = Data.decode(reader, reader.uint32());
-          continue;
-        }
-        case 6: {
-          if (tag !== 50) {
-            break;
-          }
-
-          message.cond = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 7: {
-          if (tag !== 58) {
-            break;
-          }
-
-          message.output = Output.decode(reader, reader.uint32());
-          continue;
-        }
-        case 8: {
-          if (tag !== 66) {
-            break;
-          }
-
-          message.timeout = Duration.decode(reader, reader.uint32());
-          continue;
-        }
-        case 9: {
-          if (tag !== 72) {
-            break;
-          }
-
-          message.parallel = reader.bool();
-          continue;
-        }
-        case 10: {
-          if (tag !== 82) {
-            break;
-          }
-
-          message.explain = Explain.decode(reader, reader.uint32());
-          continue;
-        }
-        case 11: {
-          if (tag !== 90) {
-            break;
-          }
-
-          message.variables = Variables.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): UpsertRequest {
-    return {
-      txn: isSet(object.txn) ? Uuid.fromJSON(object.txn) : undefined,
-      only: isSet(object.only) ? globalThis.Boolean(object.only) : false,
-      what: globalThis.Array.isArray(object?.what) ? object.what.map((e: any) => Value.fromJSON(e)) : [],
-      with: isSet(object.with) ? With.fromJSON(object.with) : undefined,
-      data: isSet(object.data) ? Data.fromJSON(object.data) : undefined,
-      cond: isSet(object.cond) ? Value.fromJSON(object.cond) : undefined,
-      output: isSet(object.output) ? Output.fromJSON(object.output) : undefined,
-      timeout: isSet(object.timeout) ? Duration.fromJSON(object.timeout) : undefined,
-      parallel: isSet(object.parallel) ? globalThis.Boolean(object.parallel) : false,
-      explain: isSet(object.explain) ? Explain.fromJSON(object.explain) : undefined,
-      variables: isSet(object.variables) ? Variables.fromJSON(object.variables) : undefined,
-    };
-  },
-
-  toJSON(message: UpsertRequest): unknown {
-    const obj: any = {};
-    if (message.txn !== undefined) {
-      obj.txn = Uuid.toJSON(message.txn);
-    }
-    if (message.only !== false) {
-      obj.only = message.only;
-    }
-    if (message.what?.length) {
-      obj.what = message.what.map((e) => Value.toJSON(e));
-    }
-    if (message.with !== undefined) {
-      obj.with = With.toJSON(message.with);
-    }
-    if (message.data !== undefined) {
-      obj.data = Data.toJSON(message.data);
-    }
-    if (message.cond !== undefined) {
-      obj.cond = Value.toJSON(message.cond);
-    }
-    if (message.output !== undefined) {
-      obj.output = Output.toJSON(message.output);
-    }
-    if (message.timeout !== undefined) {
-      obj.timeout = Duration.toJSON(message.timeout);
-    }
-    if (message.parallel !== false) {
-      obj.parallel = message.parallel;
-    }
-    if (message.explain !== undefined) {
-      obj.explain = Explain.toJSON(message.explain);
-    }
-    if (message.variables !== undefined) {
-      obj.variables = Variables.toJSON(message.variables);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<UpsertRequest>, I>>(base?: I): UpsertRequest {
-    return UpsertRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<UpsertRequest>, I>>(object: I): UpsertRequest {
-    const message = createBaseUpsertRequest();
-    message.txn = (object.txn !== undefined && object.txn !== null) ? Uuid.fromPartial(object.txn) : undefined;
-    message.only = object.only ?? false;
-    message.what = object.what?.map((e) => Value.fromPartial(e)) || [];
-    message.with = (object.with !== undefined && object.with !== null) ? With.fromPartial(object.with) : undefined;
-    message.data = (object.data !== undefined && object.data !== null) ? Data.fromPartial(object.data) : undefined;
-    message.cond = (object.cond !== undefined && object.cond !== null) ? Value.fromPartial(object.cond) : undefined;
-    message.output = (object.output !== undefined && object.output !== null)
-      ? Output.fromPartial(object.output)
-      : undefined;
-    message.timeout = (object.timeout !== undefined && object.timeout !== null)
-      ? Duration.fromPartial(object.timeout)
-      : undefined;
-    message.parallel = object.parallel ?? false;
-    message.explain = (object.explain !== undefined && object.explain !== null)
-      ? Explain.fromPartial(object.explain)
-      : undefined;
-    message.variables = (object.variables !== undefined && object.variables !== null)
-      ? Variables.fromPartial(object.variables)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseUpsertResponse(): UpsertResponse {
-  return { values: undefined };
-}
-
-export const UpsertResponse: MessageFns<UpsertResponse> = {
-  encode(message: UpsertResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): UpsertResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseUpsertResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): UpsertResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: UpsertResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<UpsertResponse>, I>>(base?: I): UpsertResponse {
-    return UpsertResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<UpsertResponse>, I>>(object: I): UpsertResponse {
-    const message = createBaseUpsertResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseUpdateRequest(): UpdateRequest {
-  return {
-    txn: undefined,
-    only: false,
-    what: [],
-    with: undefined,
-    data: undefined,
-    cond: undefined,
-    output: undefined,
-    timeout: undefined,
-    parallel: false,
-    explain: undefined,
-    variables: undefined,
-  };
-}
-
-export const UpdateRequest: MessageFns<UpdateRequest> = {
-  encode(message: UpdateRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.txn !== undefined) {
-      Uuid.encode(message.txn, writer.uint32(10).fork()).join();
-    }
-    if (message.only !== false) {
-      writer.uint32(16).bool(message.only);
-    }
-    for (const v of message.what) {
-      Value.encode(v!, writer.uint32(26).fork()).join();
-    }
-    if (message.with !== undefined) {
-      With.encode(message.with, writer.uint32(34).fork()).join();
-    }
-    if (message.data !== undefined) {
-      Data.encode(message.data, writer.uint32(42).fork()).join();
-    }
-    if (message.cond !== undefined) {
-      Value.encode(message.cond, writer.uint32(50).fork()).join();
-    }
-    if (message.output !== undefined) {
-      Output.encode(message.output, writer.uint32(58).fork()).join();
-    }
-    if (message.timeout !== undefined) {
-      Duration.encode(message.timeout, writer.uint32(74).fork()).join();
-    }
-    if (message.parallel !== false) {
-      writer.uint32(80).bool(message.parallel);
-    }
-    if (message.explain !== undefined) {
-      Explain.encode(message.explain, writer.uint32(90).fork()).join();
-    }
-    if (message.variables !== undefined) {
-      Variables.encode(message.variables, writer.uint32(98).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): UpdateRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseUpdateRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.txn = Uuid.decode(reader, reader.uint32());
-          continue;
-        }
-        case 2: {
-          if (tag !== 16) {
-            break;
-          }
-
-          message.only = reader.bool();
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.what.push(Value.decode(reader, reader.uint32()));
-          continue;
-        }
-        case 4: {
-          if (tag !== 34) {
-            break;
-          }
-
-          message.with = With.decode(reader, reader.uint32());
-          continue;
-        }
-        case 5: {
-          if (tag !== 42) {
-            break;
-          }
-
-          message.data = Data.decode(reader, reader.uint32());
-          continue;
-        }
-        case 6: {
-          if (tag !== 50) {
-            break;
-          }
-
-          message.cond = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 7: {
-          if (tag !== 58) {
-            break;
-          }
-
-          message.output = Output.decode(reader, reader.uint32());
-          continue;
-        }
-        case 9: {
-          if (tag !== 74) {
-            break;
-          }
-
-          message.timeout = Duration.decode(reader, reader.uint32());
-          continue;
-        }
-        case 10: {
-          if (tag !== 80) {
-            break;
-          }
-
-          message.parallel = reader.bool();
-          continue;
-        }
-        case 11: {
-          if (tag !== 90) {
-            break;
-          }
-
-          message.explain = Explain.decode(reader, reader.uint32());
-          continue;
-        }
-        case 12: {
-          if (tag !== 98) {
-            break;
-          }
-
-          message.variables = Variables.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): UpdateRequest {
-    return {
-      txn: isSet(object.txn) ? Uuid.fromJSON(object.txn) : undefined,
-      only: isSet(object.only) ? globalThis.Boolean(object.only) : false,
-      what: globalThis.Array.isArray(object?.what) ? object.what.map((e: any) => Value.fromJSON(e)) : [],
-      with: isSet(object.with) ? With.fromJSON(object.with) : undefined,
-      data: isSet(object.data) ? Data.fromJSON(object.data) : undefined,
-      cond: isSet(object.cond) ? Value.fromJSON(object.cond) : undefined,
-      output: isSet(object.output) ? Output.fromJSON(object.output) : undefined,
-      timeout: isSet(object.timeout) ? Duration.fromJSON(object.timeout) : undefined,
-      parallel: isSet(object.parallel) ? globalThis.Boolean(object.parallel) : false,
-      explain: isSet(object.explain) ? Explain.fromJSON(object.explain) : undefined,
-      variables: isSet(object.variables) ? Variables.fromJSON(object.variables) : undefined,
-    };
-  },
-
-  toJSON(message: UpdateRequest): unknown {
-    const obj: any = {};
-    if (message.txn !== undefined) {
-      obj.txn = Uuid.toJSON(message.txn);
-    }
-    if (message.only !== false) {
-      obj.only = message.only;
-    }
-    if (message.what?.length) {
-      obj.what = message.what.map((e) => Value.toJSON(e));
-    }
-    if (message.with !== undefined) {
-      obj.with = With.toJSON(message.with);
-    }
-    if (message.data !== undefined) {
-      obj.data = Data.toJSON(message.data);
-    }
-    if (message.cond !== undefined) {
-      obj.cond = Value.toJSON(message.cond);
-    }
-    if (message.output !== undefined) {
-      obj.output = Output.toJSON(message.output);
-    }
-    if (message.timeout !== undefined) {
-      obj.timeout = Duration.toJSON(message.timeout);
-    }
-    if (message.parallel !== false) {
-      obj.parallel = message.parallel;
-    }
-    if (message.explain !== undefined) {
-      obj.explain = Explain.toJSON(message.explain);
-    }
-    if (message.variables !== undefined) {
-      obj.variables = Variables.toJSON(message.variables);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<UpdateRequest>, I>>(base?: I): UpdateRequest {
-    return UpdateRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<UpdateRequest>, I>>(object: I): UpdateRequest {
-    const message = createBaseUpdateRequest();
-    message.txn = (object.txn !== undefined && object.txn !== null) ? Uuid.fromPartial(object.txn) : undefined;
-    message.only = object.only ?? false;
-    message.what = object.what?.map((e) => Value.fromPartial(e)) || [];
-    message.with = (object.with !== undefined && object.with !== null) ? With.fromPartial(object.with) : undefined;
-    message.data = (object.data !== undefined && object.data !== null) ? Data.fromPartial(object.data) : undefined;
-    message.cond = (object.cond !== undefined && object.cond !== null) ? Value.fromPartial(object.cond) : undefined;
-    message.output = (object.output !== undefined && object.output !== null)
-      ? Output.fromPartial(object.output)
-      : undefined;
-    message.timeout = (object.timeout !== undefined && object.timeout !== null)
-      ? Duration.fromPartial(object.timeout)
-      : undefined;
-    message.parallel = object.parallel ?? false;
-    message.explain = (object.explain !== undefined && object.explain !== null)
-      ? Explain.fromPartial(object.explain)
-      : undefined;
-    message.variables = (object.variables !== undefined && object.variables !== null)
-      ? Variables.fromPartial(object.variables)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseUpdateResponse(): UpdateResponse {
-  return { values: undefined };
-}
-
-export const UpdateResponse: MessageFns<UpdateResponse> = {
-  encode(message: UpdateResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): UpdateResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseUpdateResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): UpdateResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: UpdateResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<UpdateResponse>, I>>(base?: I): UpdateResponse {
-    return UpdateResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<UpdateResponse>, I>>(object: I): UpdateResponse {
-    const message = createBaseUpdateResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseDeleteRequest(): DeleteRequest {
-  return {
-    txn: undefined,
-    only: false,
-    what: [],
-    with: undefined,
-    cond: undefined,
-    output: undefined,
-    timeout: undefined,
-    parallel: false,
-    explain: undefined,
-    variables: undefined,
-  };
-}
-
-export const DeleteRequest: MessageFns<DeleteRequest> = {
-  encode(message: DeleteRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.txn !== undefined) {
-      Uuid.encode(message.txn, writer.uint32(10).fork()).join();
-    }
-    if (message.only !== false) {
-      writer.uint32(16).bool(message.only);
-    }
-    for (const v of message.what) {
-      Value.encode(v!, writer.uint32(26).fork()).join();
-    }
-    if (message.with !== undefined) {
-      With.encode(message.with, writer.uint32(34).fork()).join();
-    }
-    if (message.cond !== undefined) {
-      Value.encode(message.cond, writer.uint32(42).fork()).join();
-    }
-    if (message.output !== undefined) {
-      Output.encode(message.output, writer.uint32(50).fork()).join();
-    }
-    if (message.timeout !== undefined) {
-      Duration.encode(message.timeout, writer.uint32(58).fork()).join();
-    }
-    if (message.parallel !== false) {
-      writer.uint32(64).bool(message.parallel);
-    }
-    if (message.explain !== undefined) {
-      Explain.encode(message.explain, writer.uint32(74).fork()).join();
-    }
-    if (message.variables !== undefined) {
-      Variables.encode(message.variables, writer.uint32(82).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): DeleteRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseDeleteRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.txn = Uuid.decode(reader, reader.uint32());
-          continue;
-        }
-        case 2: {
-          if (tag !== 16) {
-            break;
-          }
-
-          message.only = reader.bool();
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.what.push(Value.decode(reader, reader.uint32()));
-          continue;
-        }
-        case 4: {
-          if (tag !== 34) {
-            break;
-          }
-
-          message.with = With.decode(reader, reader.uint32());
-          continue;
-        }
-        case 5: {
-          if (tag !== 42) {
-            break;
-          }
-
-          message.cond = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 6: {
-          if (tag !== 50) {
-            break;
-          }
-
-          message.output = Output.decode(reader, reader.uint32());
-          continue;
-        }
-        case 7: {
-          if (tag !== 58) {
-            break;
-          }
-
-          message.timeout = Duration.decode(reader, reader.uint32());
-          continue;
-        }
-        case 8: {
-          if (tag !== 64) {
-            break;
-          }
-
-          message.parallel = reader.bool();
-          continue;
-        }
-        case 9: {
-          if (tag !== 74) {
-            break;
-          }
-
-          message.explain = Explain.decode(reader, reader.uint32());
-          continue;
-        }
-        case 10: {
-          if (tag !== 82) {
-            break;
-          }
-
-          message.variables = Variables.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): DeleteRequest {
-    return {
-      txn: isSet(object.txn) ? Uuid.fromJSON(object.txn) : undefined,
-      only: isSet(object.only) ? globalThis.Boolean(object.only) : false,
-      what: globalThis.Array.isArray(object?.what) ? object.what.map((e: any) => Value.fromJSON(e)) : [],
-      with: isSet(object.with) ? With.fromJSON(object.with) : undefined,
-      cond: isSet(object.cond) ? Value.fromJSON(object.cond) : undefined,
-      output: isSet(object.output) ? Output.fromJSON(object.output) : undefined,
-      timeout: isSet(object.timeout) ? Duration.fromJSON(object.timeout) : undefined,
-      parallel: isSet(object.parallel) ? globalThis.Boolean(object.parallel) : false,
-      explain: isSet(object.explain) ? Explain.fromJSON(object.explain) : undefined,
-      variables: isSet(object.variables) ? Variables.fromJSON(object.variables) : undefined,
-    };
-  },
-
-  toJSON(message: DeleteRequest): unknown {
-    const obj: any = {};
-    if (message.txn !== undefined) {
-      obj.txn = Uuid.toJSON(message.txn);
-    }
-    if (message.only !== false) {
-      obj.only = message.only;
-    }
-    if (message.what?.length) {
-      obj.what = message.what.map((e) => Value.toJSON(e));
-    }
-    if (message.with !== undefined) {
-      obj.with = With.toJSON(message.with);
-    }
-    if (message.cond !== undefined) {
-      obj.cond = Value.toJSON(message.cond);
-    }
-    if (message.output !== undefined) {
-      obj.output = Output.toJSON(message.output);
-    }
-    if (message.timeout !== undefined) {
-      obj.timeout = Duration.toJSON(message.timeout);
-    }
-    if (message.parallel !== false) {
-      obj.parallel = message.parallel;
-    }
-    if (message.explain !== undefined) {
-      obj.explain = Explain.toJSON(message.explain);
-    }
-    if (message.variables !== undefined) {
-      obj.variables = Variables.toJSON(message.variables);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<DeleteRequest>, I>>(base?: I): DeleteRequest {
-    return DeleteRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<DeleteRequest>, I>>(object: I): DeleteRequest {
-    const message = createBaseDeleteRequest();
-    message.txn = (object.txn !== undefined && object.txn !== null) ? Uuid.fromPartial(object.txn) : undefined;
-    message.only = object.only ?? false;
-    message.what = object.what?.map((e) => Value.fromPartial(e)) || [];
-    message.with = (object.with !== undefined && object.with !== null) ? With.fromPartial(object.with) : undefined;
-    message.cond = (object.cond !== undefined && object.cond !== null) ? Value.fromPartial(object.cond) : undefined;
-    message.output = (object.output !== undefined && object.output !== null)
-      ? Output.fromPartial(object.output)
-      : undefined;
-    message.timeout = (object.timeout !== undefined && object.timeout !== null)
-      ? Duration.fromPartial(object.timeout)
-      : undefined;
-    message.parallel = object.parallel ?? false;
-    message.explain = (object.explain !== undefined && object.explain !== null)
-      ? Explain.fromPartial(object.explain)
-      : undefined;
-    message.variables = (object.variables !== undefined && object.variables !== null)
-      ? Variables.fromPartial(object.variables)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseDeleteResponse(): DeleteResponse {
-  return { values: undefined };
-}
-
-export const DeleteResponse: MessageFns<DeleteResponse> = {
-  encode(message: DeleteResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): DeleteResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseDeleteResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): DeleteResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: DeleteResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<DeleteResponse>, I>>(base?: I): DeleteResponse {
-    return DeleteResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<DeleteResponse>, I>>(object: I): DeleteResponse {
-    const message = createBaseDeleteResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
     return message;
   },
 };
@@ -3955,7 +1188,7 @@ export const QueryRequest: MessageFns<QueryRequest> = {
 };
 
 function createBaseQueryResponse(): QueryResponse {
-  return { queryIndex: 0, batchIndex: 0n, stats: undefined, values: undefined };
+  return { queryIndex: 0, batchIndex: 0n, stats: undefined, error: undefined, values: [] };
 }
 
 export const QueryResponse: MessageFns<QueryResponse> = {
@@ -3972,8 +1205,11 @@ export const QueryResponse: MessageFns<QueryResponse> = {
     if (message.stats !== undefined) {
       QueryStats.encode(message.stats, writer.uint32(26).fork()).join();
     }
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(34).fork()).join();
+    if (message.error !== undefined) {
+      QueryError.encode(message.error, writer.uint32(34).fork()).join();
+    }
+    for (const v of message.values) {
+      Value.encode(v!, writer.uint32(42).fork()).join();
     }
     return writer;
   },
@@ -4014,7 +1250,15 @@ export const QueryResponse: MessageFns<QueryResponse> = {
             break;
           }
 
-          message.values = ValueBatch.decode(reader, reader.uint32());
+          message.error = QueryError.decode(reader, reader.uint32());
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.values.push(Value.decode(reader, reader.uint32()));
           continue;
         }
       }
@@ -4031,7 +1275,8 @@ export const QueryResponse: MessageFns<QueryResponse> = {
       queryIndex: isSet(object.queryIndex) ? globalThis.Number(object.queryIndex) : 0,
       batchIndex: isSet(object.batchIndex) ? BigInt(object.batchIndex) : 0n,
       stats: isSet(object.stats) ? QueryStats.fromJSON(object.stats) : undefined,
-      values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined,
+      error: isSet(object.error) ? QueryError.fromJSON(object.error) : undefined,
+      values: globalThis.Array.isArray(object?.values) ? object.values.map((e: any) => Value.fromJSON(e)) : [],
     };
   },
 
@@ -4046,8 +1291,11 @@ export const QueryResponse: MessageFns<QueryResponse> = {
     if (message.stats !== undefined) {
       obj.stats = QueryStats.toJSON(message.stats);
     }
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
+    if (message.error !== undefined) {
+      obj.error = QueryError.toJSON(message.error);
+    }
+    if (message.values?.length) {
+      obj.values = message.values.map((e) => Value.toJSON(e));
     }
     return obj;
   },
@@ -4062,30 +1310,56 @@ export const QueryResponse: MessageFns<QueryResponse> = {
     message.stats = (object.stats !== undefined && object.stats !== null)
       ? QueryStats.fromPartial(object.stats)
       : undefined;
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
+    message.error = (object.error !== undefined && object.error !== null)
+      ? QueryError.fromPartial(object.error)
       : undefined;
+    message.values = object.values?.map((e) => Value.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseQueryStats(): QueryStats {
-  return { numRecords: 0n, startTime: undefined, executionDuration: undefined };
+  return {
+    recordsReturned: 0n,
+    bytesReturned: 0n,
+    recordsScanned: 0n,
+    bytesScanned: 0n,
+    startTime: undefined,
+    executionDuration: undefined,
+  };
 }
 
 export const QueryStats: MessageFns<QueryStats> = {
   encode(message: QueryStats, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.numRecords !== 0n) {
-      if (BigInt.asIntN(64, message.numRecords) !== message.numRecords) {
-        throw new globalThis.Error("value provided for field message.numRecords of type int64 too large");
+    if (message.recordsReturned !== 0n) {
+      if (BigInt.asIntN(64, message.recordsReturned) !== message.recordsReturned) {
+        throw new globalThis.Error("value provided for field message.recordsReturned of type int64 too large");
       }
-      writer.uint32(8).int64(message.numRecords);
+      writer.uint32(8).int64(message.recordsReturned);
+    }
+    if (message.bytesReturned !== 0n) {
+      if (BigInt.asIntN(64, message.bytesReturned) !== message.bytesReturned) {
+        throw new globalThis.Error("value provided for field message.bytesReturned of type int64 too large");
+      }
+      writer.uint32(16).int64(message.bytesReturned);
+    }
+    if (message.recordsScanned !== 0n) {
+      if (BigInt.asIntN(64, message.recordsScanned) !== message.recordsScanned) {
+        throw new globalThis.Error("value provided for field message.recordsScanned of type int64 too large");
+      }
+      writer.uint32(24).int64(message.recordsScanned);
+    }
+    if (message.bytesScanned !== 0n) {
+      if (BigInt.asIntN(64, message.bytesScanned) !== message.bytesScanned) {
+        throw new globalThis.Error("value provided for field message.bytesScanned of type int64 too large");
+      }
+      writer.uint32(32).int64(message.bytesScanned);
     }
     if (message.startTime !== undefined) {
-      Timestamp.encode(toTimestamp(message.startTime), writer.uint32(18).fork()).join();
+      Timestamp.encode(toTimestamp(message.startTime), writer.uint32(42).fork()).join();
     }
     if (message.executionDuration !== undefined) {
-      Duration.encode(message.executionDuration, writer.uint32(26).fork()).join();
+      Duration.encode(message.executionDuration, writer.uint32(50).fork()).join();
     }
     return writer;
   },
@@ -4102,19 +1376,43 @@ export const QueryStats: MessageFns<QueryStats> = {
             break;
           }
 
-          message.numRecords = reader.int64() as bigint;
+          message.recordsReturned = reader.int64() as bigint;
           continue;
         }
         case 2: {
-          if (tag !== 18) {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.bytesReturned = reader.int64() as bigint;
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.recordsScanned = reader.int64() as bigint;
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.bytesScanned = reader.int64() as bigint;
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
             break;
           }
 
           message.startTime = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
           continue;
         }
-        case 3: {
-          if (tag !== 26) {
+        case 6: {
+          if (tag !== 50) {
             break;
           }
 
@@ -4132,7 +1430,10 @@ export const QueryStats: MessageFns<QueryStats> = {
 
   fromJSON(object: any): QueryStats {
     return {
-      numRecords: isSet(object.numRecords) ? BigInt(object.numRecords) : 0n,
+      recordsReturned: isSet(object.recordsReturned) ? BigInt(object.recordsReturned) : 0n,
+      bytesReturned: isSet(object.bytesReturned) ? BigInt(object.bytesReturned) : 0n,
+      recordsScanned: isSet(object.recordsScanned) ? BigInt(object.recordsScanned) : 0n,
+      bytesScanned: isSet(object.bytesScanned) ? BigInt(object.bytesScanned) : 0n,
       startTime: isSet(object.startTime) ? fromJsonTimestamp(object.startTime) : undefined,
       executionDuration: isSet(object.executionDuration) ? Duration.fromJSON(object.executionDuration) : undefined,
     };
@@ -4140,8 +1441,17 @@ export const QueryStats: MessageFns<QueryStats> = {
 
   toJSON(message: QueryStats): unknown {
     const obj: any = {};
-    if (message.numRecords !== 0n) {
-      obj.numRecords = message.numRecords.toString();
+    if (message.recordsReturned !== 0n) {
+      obj.recordsReturned = message.recordsReturned.toString();
+    }
+    if (message.bytesReturned !== 0n) {
+      obj.bytesReturned = message.bytesReturned.toString();
+    }
+    if (message.recordsScanned !== 0n) {
+      obj.recordsScanned = message.recordsScanned.toString();
+    }
+    if (message.bytesScanned !== 0n) {
+      obj.bytesScanned = message.bytesScanned.toString();
     }
     if (message.startTime !== undefined) {
       obj.startTime = message.startTime.toISOString();
@@ -4157,7 +1467,10 @@ export const QueryStats: MessageFns<QueryStats> = {
   },
   fromPartial<I extends Exact<DeepPartial<QueryStats>, I>>(object: I): QueryStats {
     const message = createBaseQueryStats();
-    message.numRecords = object.numRecords ?? 0n;
+    message.recordsReturned = object.recordsReturned ?? 0n;
+    message.bytesReturned = object.bytesReturned ?? 0n;
+    message.recordsScanned = object.recordsScanned ?? 0n;
+    message.bytesScanned = object.bytesScanned ?? 0n;
     message.startTime = object.startTime ?? undefined;
     message.executionDuration = (object.executionDuration !== undefined && object.executionDuration !== null)
       ? Duration.fromPartial(object.executionDuration)
@@ -4166,335 +1479,37 @@ export const QueryStats: MessageFns<QueryStats> = {
   },
 };
 
-function createBaseRelateRequest(): RelateRequest {
-  return {
-    txn: undefined,
-    only: false,
-    kind: undefined,
-    from: undefined,
-    with: undefined,
-    uniq: false,
-    data: undefined,
-    output: undefined,
-    timeout: undefined,
-    parallel: false,
-    variables: undefined,
-  };
+function createBaseQueryError(): QueryError {
+  return { code: 0n, message: "" };
 }
 
-export const RelateRequest: MessageFns<RelateRequest> = {
-  encode(message: RelateRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.txn !== undefined) {
-      Uuid.encode(message.txn, writer.uint32(10).fork()).join();
+export const QueryError: MessageFns<QueryError> = {
+  encode(message: QueryError, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.code !== 0n) {
+      if (BigInt.asIntN(64, message.code) !== message.code) {
+        throw new globalThis.Error("value provided for field message.code of type int64 too large");
+      }
+      writer.uint32(8).int64(message.code);
     }
-    if (message.only !== false) {
-      writer.uint32(16).bool(message.only);
-    }
-    if (message.kind !== undefined) {
-      Value.encode(message.kind, writer.uint32(26).fork()).join();
-    }
-    if (message.from !== undefined) {
-      Value.encode(message.from, writer.uint32(34).fork()).join();
-    }
-    if (message.with !== undefined) {
-      Value.encode(message.with, writer.uint32(42).fork()).join();
-    }
-    if (message.uniq !== false) {
-      writer.uint32(48).bool(message.uniq);
-    }
-    if (message.data !== undefined) {
-      Data.encode(message.data, writer.uint32(58).fork()).join();
-    }
-    if (message.output !== undefined) {
-      Output.encode(message.output, writer.uint32(66).fork()).join();
-    }
-    if (message.timeout !== undefined) {
-      Duration.encode(message.timeout, writer.uint32(74).fork()).join();
-    }
-    if (message.parallel !== false) {
-      writer.uint32(80).bool(message.parallel);
-    }
-    if (message.variables !== undefined) {
-      Variables.encode(message.variables, writer.uint32(90).fork()).join();
+    if (message.message !== "") {
+      writer.uint32(18).string(message.message);
     }
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): RelateRequest {
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryError {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseRelateRequest();
+    const message = createBaseQueryError();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1: {
-          if (tag !== 10) {
+          if (tag !== 8) {
             break;
           }
 
-          message.txn = Uuid.decode(reader, reader.uint32());
-          continue;
-        }
-        case 2: {
-          if (tag !== 16) {
-            break;
-          }
-
-          message.only = reader.bool();
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.kind = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 4: {
-          if (tag !== 34) {
-            break;
-          }
-
-          message.from = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 5: {
-          if (tag !== 42) {
-            break;
-          }
-
-          message.with = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 6: {
-          if (tag !== 48) {
-            break;
-          }
-
-          message.uniq = reader.bool();
-          continue;
-        }
-        case 7: {
-          if (tag !== 58) {
-            break;
-          }
-
-          message.data = Data.decode(reader, reader.uint32());
-          continue;
-        }
-        case 8: {
-          if (tag !== 66) {
-            break;
-          }
-
-          message.output = Output.decode(reader, reader.uint32());
-          continue;
-        }
-        case 9: {
-          if (tag !== 74) {
-            break;
-          }
-
-          message.timeout = Duration.decode(reader, reader.uint32());
-          continue;
-        }
-        case 10: {
-          if (tag !== 80) {
-            break;
-          }
-
-          message.parallel = reader.bool();
-          continue;
-        }
-        case 11: {
-          if (tag !== 90) {
-            break;
-          }
-
-          message.variables = Variables.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): RelateRequest {
-    return {
-      txn: isSet(object.txn) ? Uuid.fromJSON(object.txn) : undefined,
-      only: isSet(object.only) ? globalThis.Boolean(object.only) : false,
-      kind: isSet(object.kind) ? Value.fromJSON(object.kind) : undefined,
-      from: isSet(object.from) ? Value.fromJSON(object.from) : undefined,
-      with: isSet(object.with) ? Value.fromJSON(object.with) : undefined,
-      uniq: isSet(object.uniq) ? globalThis.Boolean(object.uniq) : false,
-      data: isSet(object.data) ? Data.fromJSON(object.data) : undefined,
-      output: isSet(object.output) ? Output.fromJSON(object.output) : undefined,
-      timeout: isSet(object.timeout) ? Duration.fromJSON(object.timeout) : undefined,
-      parallel: isSet(object.parallel) ? globalThis.Boolean(object.parallel) : false,
-      variables: isSet(object.variables) ? Variables.fromJSON(object.variables) : undefined,
-    };
-  },
-
-  toJSON(message: RelateRequest): unknown {
-    const obj: any = {};
-    if (message.txn !== undefined) {
-      obj.txn = Uuid.toJSON(message.txn);
-    }
-    if (message.only !== false) {
-      obj.only = message.only;
-    }
-    if (message.kind !== undefined) {
-      obj.kind = Value.toJSON(message.kind);
-    }
-    if (message.from !== undefined) {
-      obj.from = Value.toJSON(message.from);
-    }
-    if (message.with !== undefined) {
-      obj.with = Value.toJSON(message.with);
-    }
-    if (message.uniq !== false) {
-      obj.uniq = message.uniq;
-    }
-    if (message.data !== undefined) {
-      obj.data = Data.toJSON(message.data);
-    }
-    if (message.output !== undefined) {
-      obj.output = Output.toJSON(message.output);
-    }
-    if (message.timeout !== undefined) {
-      obj.timeout = Duration.toJSON(message.timeout);
-    }
-    if (message.parallel !== false) {
-      obj.parallel = message.parallel;
-    }
-    if (message.variables !== undefined) {
-      obj.variables = Variables.toJSON(message.variables);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<RelateRequest>, I>>(base?: I): RelateRequest {
-    return RelateRequest.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<RelateRequest>, I>>(object: I): RelateRequest {
-    const message = createBaseRelateRequest();
-    message.txn = (object.txn !== undefined && object.txn !== null) ? Uuid.fromPartial(object.txn) : undefined;
-    message.only = object.only ?? false;
-    message.kind = (object.kind !== undefined && object.kind !== null) ? Value.fromPartial(object.kind) : undefined;
-    message.from = (object.from !== undefined && object.from !== null) ? Value.fromPartial(object.from) : undefined;
-    message.with = (object.with !== undefined && object.with !== null) ? Value.fromPartial(object.with) : undefined;
-    message.uniq = object.uniq ?? false;
-    message.data = (object.data !== undefined && object.data !== null) ? Data.fromPartial(object.data) : undefined;
-    message.output = (object.output !== undefined && object.output !== null)
-      ? Output.fromPartial(object.output)
-      : undefined;
-    message.timeout = (object.timeout !== undefined && object.timeout !== null)
-      ? Duration.fromPartial(object.timeout)
-      : undefined;
-    message.parallel = object.parallel ?? false;
-    message.variables = (object.variables !== undefined && object.variables !== null)
-      ? Variables.fromPartial(object.variables)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseRelateResponse(): RelateResponse {
-  return { values: undefined };
-}
-
-export const RelateResponse: MessageFns<RelateResponse> = {
-  encode(message: RelateResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): RelateResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseRelateResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): RelateResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: RelateResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<RelateResponse>, I>>(base?: I): RelateResponse {
-    return RelateResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<RelateResponse>, I>>(object: I): RelateResponse {
-    const message = createBaseRelateResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseRunFunctionRequest(): RunFunctionRequest {
-  return { name: "", version: "", args: [] };
-}
-
-export const RunFunctionRequest: MessageFns<RunFunctionRequest> = {
-  encode(message: RunFunctionRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.name !== "") {
-      writer.uint32(10).string(message.name);
-    }
-    if (message.version !== "") {
-      writer.uint32(18).string(message.version);
-    }
-    for (const v of message.args) {
-      Value.encode(v!, writer.uint32(26).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): RunFunctionRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseRunFunctionRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.name = reader.string();
+          message.code = reader.int64() as bigint;
           continue;
         }
         case 2: {
@@ -4502,15 +1517,7 @@ export const RunFunctionRequest: MessageFns<RunFunctionRequest> = {
             break;
           }
 
-          message.version = reader.string();
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.args.push(Value.decode(reader, reader.uint32()));
+          message.message = reader.string();
           continue;
         }
       }
@@ -4522,154 +1529,31 @@ export const RunFunctionRequest: MessageFns<RunFunctionRequest> = {
     return message;
   },
 
-  fromJSON(object: any): RunFunctionRequest {
+  fromJSON(object: any): QueryError {
     return {
-      name: isSet(object.name) ? globalThis.String(object.name) : "",
-      version: isSet(object.version) ? globalThis.String(object.version) : "",
-      args: globalThis.Array.isArray(object?.args) ? object.args.map((e: any) => Value.fromJSON(e)) : [],
+      code: isSet(object.code) ? BigInt(object.code) : 0n,
+      message: isSet(object.message) ? globalThis.String(object.message) : "",
     };
   },
 
-  toJSON(message: RunFunctionRequest): unknown {
+  toJSON(message: QueryError): unknown {
     const obj: any = {};
-    if (message.name !== "") {
-      obj.name = message.name;
+    if (message.code !== 0n) {
+      obj.code = message.code.toString();
     }
-    if (message.version !== "") {
-      obj.version = message.version;
-    }
-    if (message.args?.length) {
-      obj.args = message.args.map((e) => Value.toJSON(e));
+    if (message.message !== "") {
+      obj.message = message.message;
     }
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<RunFunctionRequest>, I>>(base?: I): RunFunctionRequest {
-    return RunFunctionRequest.fromPartial(base ?? ({} as any));
+  create<I extends Exact<DeepPartial<QueryError>, I>>(base?: I): QueryError {
+    return QueryError.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<RunFunctionRequest>, I>>(object: I): RunFunctionRequest {
-    const message = createBaseRunFunctionRequest();
-    message.name = object.name ?? "";
-    message.version = object.version ?? "";
-    message.args = object.args?.map((e) => Value.fromPartial(e)) || [];
-    return message;
-  },
-};
-
-function createBaseRunFunctionResponse(): RunFunctionResponse {
-  return { values: undefined };
-}
-
-export const RunFunctionResponse: MessageFns<RunFunctionResponse> = {
-  encode(message: RunFunctionResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.values !== undefined) {
-      ValueBatch.encode(message.values, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): RunFunctionResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseRunFunctionResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values = ValueBatch.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): RunFunctionResponse {
-    return { values: isSet(object.values) ? ValueBatch.fromJSON(object.values) : undefined };
-  },
-
-  toJSON(message: RunFunctionResponse): unknown {
-    const obj: any = {};
-    if (message.values !== undefined) {
-      obj.values = ValueBatch.toJSON(message.values);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<RunFunctionResponse>, I>>(base?: I): RunFunctionResponse {
-    return RunFunctionResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<RunFunctionResponse>, I>>(object: I): RunFunctionResponse {
-    const message = createBaseRunFunctionResponse();
-    message.values = (object.values !== undefined && object.values !== null)
-      ? ValueBatch.fromPartial(object.values)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseValueBatch(): ValueBatch {
-  return { values: [] };
-}
-
-export const ValueBatch: MessageFns<ValueBatch> = {
-  encode(message: ValueBatch, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    for (const v of message.values) {
-      Value.encode(v!, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): ValueBatch {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseValueBatch();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.values.push(Value.decode(reader, reader.uint32()));
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): ValueBatch {
-    return { values: globalThis.Array.isArray(object?.values) ? object.values.map((e: any) => Value.fromJSON(e)) : [] };
-  },
-
-  toJSON(message: ValueBatch): unknown {
-    const obj: any = {};
-    if (message.values?.length) {
-      obj.values = message.values.map((e) => Value.toJSON(e));
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<ValueBatch>, I>>(base?: I): ValueBatch {
-    return ValueBatch.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<ValueBatch>, I>>(object: I): ValueBatch {
-    const message = createBaseValueBatch();
-    message.values = object.values?.map((e) => Value.fromPartial(e)) || [];
+  fromPartial<I extends Exact<DeepPartial<QueryError>, I>>(object: I): QueryError {
+    const message = createBaseQueryError();
+    message.code = object.code ?? 0n;
+    message.message = object.message ?? "";
     return message;
   },
 };
@@ -5421,118 +2305,6 @@ export const AccessMethod: MessageFns<AccessMethod> = {
   },
 };
 
-function createBaseLiveResponse(): LiveResponse {
-  return { id: undefined, action: 0, record: undefined, result: undefined };
-}
-
-export const LiveResponse: MessageFns<LiveResponse> = {
-  encode(message: LiveResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.id !== undefined) {
-      Uuid.encode(message.id, writer.uint32(10).fork()).join();
-    }
-    if (message.action !== 0) {
-      writer.uint32(16).int32(message.action);
-    }
-    if (message.record !== undefined) {
-      Value.encode(message.record, writer.uint32(26).fork()).join();
-    }
-    if (message.result !== undefined) {
-      Value.encode(message.result, writer.uint32(34).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): LiveResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseLiveResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.id = Uuid.decode(reader, reader.uint32());
-          continue;
-        }
-        case 2: {
-          if (tag !== 16) {
-            break;
-          }
-
-          message.action = reader.int32() as any;
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.record = Value.decode(reader, reader.uint32());
-          continue;
-        }
-        case 4: {
-          if (tag !== 34) {
-            break;
-          }
-
-          message.result = Value.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): LiveResponse {
-    return {
-      id: isSet(object.id) ? Uuid.fromJSON(object.id) : undefined,
-      action: isSet(object.action) ? actionFromJSON(object.action) : 0,
-      record: isSet(object.record) ? Value.fromJSON(object.record) : undefined,
-      result: isSet(object.result) ? Value.fromJSON(object.result) : undefined,
-    };
-  },
-
-  toJSON(message: LiveResponse): unknown {
-    const obj: any = {};
-    if (message.id !== undefined) {
-      obj.id = Uuid.toJSON(message.id);
-    }
-    if (message.action !== 0) {
-      obj.action = actionToJSON(message.action);
-    }
-    if (message.record !== undefined) {
-      obj.record = Value.toJSON(message.record);
-    }
-    if (message.result !== undefined) {
-      obj.result = Value.toJSON(message.result);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<LiveResponse>, I>>(base?: I): LiveResponse {
-    return LiveResponse.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<LiveResponse>, I>>(object: I): LiveResponse {
-    const message = createBaseLiveResponse();
-    message.id = (object.id !== undefined && object.id !== null) ? Uuid.fromPartial(object.id) : undefined;
-    message.action = object.action ?? 0;
-    message.record = (object.record !== undefined && object.record !== null)
-      ? Value.fromPartial(object.record)
-      : undefined;
-    message.result = (object.result !== undefined && object.result !== null)
-      ? Value.fromPartial(object.result)
-      : undefined;
-    return message;
-  },
-};
-
 function createBaseVariables(): Variables {
   return { variables: {} };
 }
@@ -5694,46 +2466,16 @@ export interface SurrealDBService {
   Health(request: HealthRequest): Promise<HealthResponse>;
   /** Get the version of the database. */
   Version(request: VersionRequest): Promise<VersionResponse>;
-  /** Get information about the database. */
-  Info(request: InfoRequest): Promise<InfoResponse>;
-  /** Query the database and get a stream of Values. */
-  Query(request: QueryRequest): Observable<QueryResponse>;
-  /** Issue a live query and get a stream of LiveResponses. */
-  Live(request: LiveRequest): Observable<LiveResponse>;
-  /** Change the current namespace and database. */
-  Use(request: UseRequest): Promise<UseResponse>;
   /** Sign up a new user. */
   Signup(request: SignupRequest): Promise<SignupResponse>;
   /** Sign in a user. */
   Signin(request: SigninRequest): Promise<SigninResponse>;
-  /** Authenticate a user. */
+  /** Authenticate a user with a token. */
   Authenticate(request: AuthenticateRequest): Promise<AuthenticateResponse>;
-  /** Invalidate a user. */
-  Invalidate(request: InvalidateRequest): Promise<InvalidateResponse>;
-  /** Reset the database. */
-  Reset(request: ResetRequest): Promise<ResetResponse>;
-  /** Kill a live query. */
-  Kill(request: KillRequest): Promise<KillResponse>;
-  /** Set a value. */
-  Set(request: SetRequest): Promise<SetResponse>;
-  /** Unset a value. */
-  Unset(request: UnsetRequest): Promise<UnsetResponse>;
-  /** Select values from the database. */
-  Select(request: SelectRequest): Promise<SelectResponse>;
-  /** Create a new record. */
-  Create(request: CreateRequest): Promise<CreateResponse>;
-  /** Insert a new record. */
-  Insert(request: InsertRequest): Promise<InsertResponse>;
-  /** Upsert a record. */
-  Upsert(request: UpsertRequest): Promise<UpsertResponse>;
-  /** Update a record. */
-  Update(request: UpdateRequest): Promise<UpdateResponse>;
-  /** Delete a record. */
-  Delete(request: DeleteRequest): Promise<DeleteResponse>;
-  /** Relate two records. */
-  Relate(request: RelateRequest): Promise<RelateResponse>;
-  /** Run a function. */
-  RunFunction(request: RunFunctionRequest): Promise<RunFunctionResponse>;
+  /** Query the database and get a stream of Values. */
+  Query(request: QueryRequest): Observable<QueryResponse>;
+  /** Issue a live query and get a stream of LiveResponses. */
+  Subscribe(request: SubscribeRequest): Observable<SubscribeResponse>;
 }
 
 export const SurrealDBServiceServiceName = "surrealdb.protocol.rpc.v1.SurrealDBService";
@@ -5745,26 +2487,11 @@ export class SurrealDBServiceClientImpl implements SurrealDBService {
     this.rpc = rpc;
     this.Health = this.Health.bind(this);
     this.Version = this.Version.bind(this);
-    this.Info = this.Info.bind(this);
-    this.Query = this.Query.bind(this);
-    this.Live = this.Live.bind(this);
-    this.Use = this.Use.bind(this);
     this.Signup = this.Signup.bind(this);
     this.Signin = this.Signin.bind(this);
     this.Authenticate = this.Authenticate.bind(this);
-    this.Invalidate = this.Invalidate.bind(this);
-    this.Reset = this.Reset.bind(this);
-    this.Kill = this.Kill.bind(this);
-    this.Set = this.Set.bind(this);
-    this.Unset = this.Unset.bind(this);
-    this.Select = this.Select.bind(this);
-    this.Create = this.Create.bind(this);
-    this.Insert = this.Insert.bind(this);
-    this.Upsert = this.Upsert.bind(this);
-    this.Update = this.Update.bind(this);
-    this.Delete = this.Delete.bind(this);
-    this.Relate = this.Relate.bind(this);
-    this.RunFunction = this.RunFunction.bind(this);
+    this.Query = this.Query.bind(this);
+    this.Subscribe = this.Subscribe.bind(this);
   }
   Health(request: HealthRequest): Promise<HealthResponse> {
     const data = HealthRequest.encode(request).finish();
@@ -5776,30 +2503,6 @@ export class SurrealDBServiceClientImpl implements SurrealDBService {
     const data = VersionRequest.encode(request).finish();
     const promise = this.rpc.request(this.service, "Version", data);
     return promise.then((data) => VersionResponse.decode(new BinaryReader(data)));
-  }
-
-  Info(request: InfoRequest): Promise<InfoResponse> {
-    const data = InfoRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Info", data);
-    return promise.then((data) => InfoResponse.decode(new BinaryReader(data)));
-  }
-
-  Query(request: QueryRequest): Observable<QueryResponse> {
-    const data = QueryRequest.encode(request).finish();
-    const result = this.rpc.serverStreamingRequest(this.service, "Query", data);
-    return result.pipe(map((data) => QueryResponse.decode(new BinaryReader(data))));
-  }
-
-  Live(request: LiveRequest): Observable<LiveResponse> {
-    const data = LiveRequest.encode(request).finish();
-    const result = this.rpc.serverStreamingRequest(this.service, "Live", data);
-    return result.pipe(map((data) => LiveResponse.decode(new BinaryReader(data))));
-  }
-
-  Use(request: UseRequest): Promise<UseResponse> {
-    const data = UseRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Use", data);
-    return promise.then((data) => UseResponse.decode(new BinaryReader(data)));
   }
 
   Signup(request: SignupRequest): Promise<SignupResponse> {
@@ -5820,82 +2523,16 @@ export class SurrealDBServiceClientImpl implements SurrealDBService {
     return promise.then((data) => AuthenticateResponse.decode(new BinaryReader(data)));
   }
 
-  Invalidate(request: InvalidateRequest): Promise<InvalidateResponse> {
-    const data = InvalidateRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Invalidate", data);
-    return promise.then((data) => InvalidateResponse.decode(new BinaryReader(data)));
+  Query(request: QueryRequest): Observable<QueryResponse> {
+    const data = QueryRequest.encode(request).finish();
+    const result = this.rpc.serverStreamingRequest(this.service, "Query", data);
+    return result.pipe(map((data) => QueryResponse.decode(new BinaryReader(data))));
   }
 
-  Reset(request: ResetRequest): Promise<ResetResponse> {
-    const data = ResetRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Reset", data);
-    return promise.then((data) => ResetResponse.decode(new BinaryReader(data)));
-  }
-
-  Kill(request: KillRequest): Promise<KillResponse> {
-    const data = KillRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Kill", data);
-    return promise.then((data) => KillResponse.decode(new BinaryReader(data)));
-  }
-
-  Set(request: SetRequest): Promise<SetResponse> {
-    const data = SetRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Set", data);
-    return promise.then((data) => SetResponse.decode(new BinaryReader(data)));
-  }
-
-  Unset(request: UnsetRequest): Promise<UnsetResponse> {
-    const data = UnsetRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Unset", data);
-    return promise.then((data) => UnsetResponse.decode(new BinaryReader(data)));
-  }
-
-  Select(request: SelectRequest): Promise<SelectResponse> {
-    const data = SelectRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Select", data);
-    return promise.then((data) => SelectResponse.decode(new BinaryReader(data)));
-  }
-
-  Create(request: CreateRequest): Promise<CreateResponse> {
-    const data = CreateRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Create", data);
-    return promise.then((data) => CreateResponse.decode(new BinaryReader(data)));
-  }
-
-  Insert(request: InsertRequest): Promise<InsertResponse> {
-    const data = InsertRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Insert", data);
-    return promise.then((data) => InsertResponse.decode(new BinaryReader(data)));
-  }
-
-  Upsert(request: UpsertRequest): Promise<UpsertResponse> {
-    const data = UpsertRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Upsert", data);
-    return promise.then((data) => UpsertResponse.decode(new BinaryReader(data)));
-  }
-
-  Update(request: UpdateRequest): Promise<UpdateResponse> {
-    const data = UpdateRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Update", data);
-    return promise.then((data) => UpdateResponse.decode(new BinaryReader(data)));
-  }
-
-  Delete(request: DeleteRequest): Promise<DeleteResponse> {
-    const data = DeleteRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Delete", data);
-    return promise.then((data) => DeleteResponse.decode(new BinaryReader(data)));
-  }
-
-  Relate(request: RelateRequest): Promise<RelateResponse> {
-    const data = RelateRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "Relate", data);
-    return promise.then((data) => RelateResponse.decode(new BinaryReader(data)));
-  }
-
-  RunFunction(request: RunFunctionRequest): Promise<RunFunctionResponse> {
-    const data = RunFunctionRequest.encode(request).finish();
-    const promise = this.rpc.request(this.service, "RunFunction", data);
-    return promise.then((data) => RunFunctionResponse.decode(new BinaryReader(data)));
+  Subscribe(request: SubscribeRequest): Observable<SubscribeResponse> {
+    const data = SubscribeRequest.encode(request).finish();
+    const result = this.rpc.serverStreamingRequest(this.service, "Subscribe", data);
+    return result.pipe(map((data) => SubscribeResponse.decode(new BinaryReader(data))));
   }
 }
 

--- a/surrealdb/protocol/rpc/v1/rpc.proto
+++ b/surrealdb/protocol/rpc/v1/rpc.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package surrealdb.protocol.rpc.v1;
 
 import "surrealdb/protocol/v1/value.proto";
-import "surrealdb/protocol/v1/expr.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -13,48 +12,18 @@ service SurrealDBService {
     rpc Health(HealthRequest) returns (HealthResponse);
     // Get the version of the database.
     rpc Version(VersionRequest) returns (VersionResponse);
-    // Get information about the database.
-    rpc Info(InfoRequest) returns (InfoResponse);
 
-    // Query the database and get a stream of Values.
-    rpc Query(QueryRequest) returns (stream QueryResponse);
-    // Issue a live query and get a stream of LiveResponses.
-    rpc Live(LiveRequest) returns (stream LiveResponse);
-
-    // Change the current namespace and database.
-    rpc Use(UseRequest) returns (UseResponse);
     // Sign up a new user.
     rpc Signup(SignupRequest) returns (SignupResponse);
     // Sign in a user.
     rpc Signin(SigninRequest) returns (SigninResponse);
-    // Authenticate a user.
+    // Authenticate a user with a token.
     rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse);
-    // Invalidate a user.
-    rpc Invalidate(InvalidateRequest) returns (InvalidateResponse);
-    // Reset the database.
-    rpc Reset(ResetRequest) returns (ResetResponse);
-    // Kill a live query.
-    rpc Kill(KillRequest) returns (KillResponse);
-    // Set a value.
-    rpc Set(SetRequest) returns (SetResponse);
-    // Unset a value.
-    rpc Unset(UnsetRequest) returns (UnsetResponse);
-    // Select values from the database.
-    rpc Select(SelectRequest) returns (SelectResponse);
-    // Create a new record.
-    rpc Create(CreateRequest) returns (CreateResponse);
-    // Insert a new record.
-    rpc Insert(InsertRequest) returns (InsertResponse);
-    // Upsert a record.
-    rpc Upsert(UpsertRequest) returns (UpsertResponse);
-    // Update a record.
-    rpc Update(UpdateRequest) returns (UpdateResponse);
-    // Delete a record.
-    rpc Delete(DeleteRequest) returns (DeleteResponse);
-    // Relate two records.
-    rpc Relate(RelateRequest) returns (RelateResponse);
-    // Run a function.
-    rpc RunFunction(RunFunctionRequest) returns (RunFunctionResponse);
+
+    // Query the database and get a stream of Values.
+    rpc Query(QueryRequest) returns (stream QueryResponse);
+    // Issue a live query and get a stream of LiveResponses.
+    rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
 }
 
 // Request to check the health of the database.
@@ -72,25 +41,6 @@ message VersionResponse {
     string version = 1;
 }
 
-// Request to get information about the database.
-message InfoRequest {}
-
-// Response to an info request.
-message InfoResponse {
-    ValueBatch values = 1;
-}
-
-// Request to change the current namespace and database.
-message UseRequest {
-    string namespace = 1;
-    string database = 2;
-}
-
-// Response to a use request.
-message UseResponse {
-    ValueBatch values = 1;
-}
-
 // Request to sign up a new user.
 message SignupRequest {
     string namespace = 1;
@@ -101,7 +51,7 @@ message SignupRequest {
 
 // Response to a signup request.
 message SignupResponse {
-    ValueBatch values = 1;
+    surrealdb.protocol.v1.Value value = 1;
 }
 
 // Request to sign in a user.
@@ -111,7 +61,7 @@ message SigninRequest {
 
 // Response to a signin request.
 message SigninResponse {
-    ValueBatch values = 1;
+    surrealdb.protocol.v1.Value value = 1;
 }
 
 // Request to authenticate a user.
@@ -121,186 +71,35 @@ message AuthenticateRequest {
 
 // Response to an authenticate request.
 message AuthenticateResponse {
-    ValueBatch values = 1;
-}
-
-// Request to invalidate a user.
-    message InvalidateRequest {}
-
-// Response to an invalidate request.
-message InvalidateResponse {
-    ValueBatch values = 1;
-}
-
-// Request to reset the database.
-message ResetRequest {}
-
-// Response to a reset request.
-message ResetResponse {
-    ValueBatch values = 1;
-}
-
-// Request to kill a live query.
-message KillRequest {
-    string live_id = 1;
-}
-
-// Response to a kill request.
-message KillResponse {
-    ValueBatch values = 1;
+    surrealdb.protocol.v1.Value value = 1;
 }
 
 // Request to issue a live query.
-message LiveRequest {
-    surrealdb.protocol.v1.Value what = 1;
-    surrealdb.protocol.v1.Fields expr = 2;
-    surrealdb.protocol.v1.Value cond = 3;
+message SubscribeRequest {
+    string query = 1;
+    Variables variables = 2;
 }
 
-// Request to set a value.
-message SetRequest {
-    string key = 1;
-    surrealdb.protocol.v1.Value value = 2;
+// Action type.
+enum Action {
+    ACTION_UNSPECIFIED = 0;
+    ACTION_CREATED = 1;
+    ACTION_UPDATED = 2;
+    ACTION_DELETED = 3;
+    ACTION_KILLED = 4;
 }
 
-// Response to a set request.
-message SetResponse {
-    ValueBatch values = 1;
+// Response to a live query.
+message SubscribeResponse {
+    Notification notification = 1;
 }
 
-// Request to unset a value.
-message UnsetRequest {
-    string key = 1;
-}
-
-// Response to an unset request.
-message UnsetResponse {
-    ValueBatch values = 1;
-}
-
-// Request to create a new record.
-message CreateRequest {
-    surrealdb.protocol.v1.Uuid txn = 1;
-    bool only = 2;
-    repeated surrealdb.protocol.v1.Value what = 3;
-    surrealdb.protocol.v1.Data data = 4;
-    surrealdb.protocol.v1.Output output = 5;
-    google.protobuf.Duration timeout = 6;
-    bool parallel = 7;
-    surrealdb.protocol.v1.Value version = 8;
-    Variables variables = 9;
-}
-
-// Response to a create request.
-message CreateResponse {
-    ValueBatch values = 1;
-}
-
-// Request to select values from the database.
-message SelectRequest {
-    surrealdb.protocol.v1.Uuid txn = 1;
-    surrealdb.protocol.v1.Fields expr = 2;
-    surrealdb.protocol.v1.Value omit = 3;
-    bool only = 4;
-    repeated surrealdb.protocol.v1.Value what = 5;
-    surrealdb.protocol.v1.Value with = 6;
-    surrealdb.protocol.v1.Value cond = 7;
-    surrealdb.protocol.v1.Value split = 8;
-    surrealdb.protocol.v1.Value group = 9;
-    surrealdb.protocol.v1.Value order = 10;
-    int64 start = 11;
-    int64 limit = 12;
-    surrealdb.protocol.v1.Fetchs fetch = 13;
-    surrealdb.protocol.v1.Value version = 14;
-    google.protobuf.Duration timeout = 15;
-    bool parallel = 16;
-    surrealdb.protocol.v1.Explain explain = 17;
-    bool tempfiles = 18;
-    Variables variables = 19;
-}
-
-// Response to a select request.
-message SelectResponse {
-    ValueBatch values = 1;
-}
-
-// Request to insert a new record.
-message InsertRequest {
-    surrealdb.protocol.v1.Uuid txn = 1;
-    surrealdb.protocol.v1.Value into = 2;
-    surrealdb.protocol.v1.Data data = 3;
-    bool ignore = 4;
-    surrealdb.protocol.v1.Value update = 5;
-    surrealdb.protocol.v1.Output output = 6;
-    google.protobuf.Duration timeout = 7;
-    bool parallel = 8;
-    bool relation = 9;
-    surrealdb.protocol.v1.Value version = 10;
-    Variables variables = 11;
-}
-
-// Response to an insert request.
-message InsertResponse {
-    ValueBatch values = 1;
-}
-
-// Request to upsert a record.
-message UpsertRequest {
-    surrealdb.protocol.v1.Uuid txn = 1;
-    bool only = 2;
-    repeated surrealdb.protocol.v1.Value what = 3;
-    surrealdb.protocol.v1.With with = 4;
-    surrealdb.protocol.v1.Data data = 5;
-    surrealdb.protocol.v1.Value cond = 6;
-    surrealdb.protocol.v1.Output output = 7;
-    google.protobuf.Duration timeout = 8;
-    bool parallel = 9;
-    surrealdb.protocol.v1.Explain explain = 10;
-    Variables variables = 11;
-}
-
-// Response to an upsert request.
-message UpsertResponse {
-    ValueBatch values = 1;
-}
-
-// Request to update a record.
-message UpdateRequest {
-    surrealdb.protocol.v1.Uuid txn = 1;
-    bool only = 2;
-    repeated surrealdb.protocol.v1.Value what = 3;
-    surrealdb.protocol.v1.With with = 4;
-    surrealdb.protocol.v1.Data data = 5;
-    surrealdb.protocol.v1.Value cond = 6;
-    surrealdb.protocol.v1.Output output = 7;
-    google.protobuf.Duration timeout = 9;
-    bool parallel = 10;
-    surrealdb.protocol.v1.Explain explain = 11;
-    Variables variables = 12;
-}
-
-// Response to an update request.
-message UpdateResponse {
-    ValueBatch values = 1;
-}
-
-// Request to delete a record.
-message DeleteRequest {
-    surrealdb.protocol.v1.Uuid txn = 1;
-    bool only = 2;
-    repeated surrealdb.protocol.v1.Value what = 3;
-    surrealdb.protocol.v1.With with = 4;
-    surrealdb.protocol.v1.Value cond = 5;
-    surrealdb.protocol.v1.Output output = 6;
-    google.protobuf.Duration timeout = 7;
-    bool parallel = 8;
-    surrealdb.protocol.v1.Explain explain = 9;
-    Variables variables = 10;
-}
-
-// Response to a delete request.
-message DeleteResponse {
-    ValueBatch values = 1;
+// A notification from a live query.
+message Notification {
+    surrealdb.protocol.v1.Uuid live_query_id = 1;
+    Action action = 2;
+    surrealdb.protocol.v1.RecordId record_id = 3;
+    surrealdb.protocol.v1.Value value = 4;
 }
 
 // Request to query the database.
@@ -318,70 +117,50 @@ message QueryRequest {
 // value batches may elide the stats.
 // 
 // Responses are ordered by query index, then batch index. For example:
-//  QueryResponse(query_index=0, batch_index=0)
-//  QueryResponse(query_index=0, batch_index=1)
-//  QueryResponse(query_index=1, batch_index=0)
-//  QueryResponse(query_index=2, batch_index=0)
-//  QueryResponse(query_index=2, batch_index=1)
-//  QueryResponse(query_index=2, batch_index=2)
-//  QueryResponse(query_index=3, batch_index=0)
-//  QueryResponse(query_index=4, batch_index=0)
+//  QueryResponse(query_index=0, batch_index=0, stats=None)
+//  QueryResponse(query_index=0, batch_index=1, stats=Some(..))
+//  QueryResponse(query_index=1, batch_index=0, stats=Some(..))
+//  QueryResponse(query_index=2, batch_index=0, stats=None)
+//  QueryResponse(query_index=2, batch_index=1, stats=None)
+//  QueryResponse(query_index=2, batch_index=2, stats=Some(..))
+//  QueryResponse(query_index=3, batch_index=0, stats=Some(..))
+//  QueryResponse(query_index=4, batch_index=0, stats=Some(..))
 message QueryResponse {
     // The index of the query.
     uint32 query_index = 1;
     // The index of the batch within the given query.
     uint64 batch_index = 2;
     // The query stats.
+    // This is only expected to be present in the last batch of each query.
     QueryStats stats = 3;
-    // The value batch.
-    ValueBatch values = 4;
+    // The error, if any.
+    QueryError error = 4;
+    // A batch of values.
+    repeated surrealdb.protocol.v1.Value values = 5;
 }
 
 // Query statistics.
 message QueryStats {
     // The number of records returned. -1 if unknown.
-    int64 num_records = 1;
+    int64 records_returned = 1;
+    // The number of bytes returned. -1 if unknown.
+    int64 bytes_returned = 2;
+    // The number of records scanned. -1 if unknown.
+    int64 records_scanned = 3;
+    // The number of bytes scanned. -1 if unknown.
+    int64 bytes_scanned = 4;
     // The start time of the query.
-    google.protobuf.Timestamp start_time = 2;
+    google.protobuf.Timestamp start_time = 5;
     // The duration of the query.
-    google.protobuf.Duration execution_duration = 3;
+    google.protobuf.Duration execution_duration = 6;
 }
 
-// Request to relate two records.
-message RelateRequest {
-    surrealdb.protocol.v1.Uuid txn = 1;
-    bool only = 2;
-    surrealdb.protocol.v1.Value kind = 3;
-    surrealdb.protocol.v1.Value from = 4;
-    surrealdb.protocol.v1.Value with = 5;
-    bool uniq = 6;
-    surrealdb.protocol.v1.Data data = 7;
-    surrealdb.protocol.v1.Output output = 8;
-    google.protobuf.Duration timeout = 9;
-    bool parallel = 10;
-    Variables variables = 11;
-}
-
-// Response to a relate request.
-message RelateResponse {
-    ValueBatch values = 1;
-}
-
-// Request to run a function.
-message RunFunctionRequest {
-    string name = 1;
-    string version = 2;
-    repeated surrealdb.protocol.v1.Value args = 3;
-}
-
-// Response to a run function request.
-message RunFunctionResponse {
-    ValueBatch values = 1;
-}
-
-// Batch of values.
-message ValueBatch {
-    repeated surrealdb.protocol.v1.Value values = 1;
+// Query error.
+message QueryError {
+    // The error code.
+    int64 code = 1;
+    // The error message.
+    string message = 2;
 }
 
 // Root user credentials.
@@ -436,23 +215,6 @@ message AccessMethod {
         DatabaseUserCredentials database_user = 5;
         AccessToken access_token = 6;
     }
-}
-
-// Action type.
-enum Action {
-    ACTION_UNSPECIFIED = 0;
-    ACTION_CREATE = 1;
-    ACTION_UPDATE = 2;
-    ACTION_DELETE = 3;
-    ACTION_KILLED = 4;
-}
-
-// Response to a live query.
-message LiveResponse {
-    surrealdb.protocol.v1.Uuid id = 1;
-    Action action = 2;
-    surrealdb.protocol.v1.Value record = 3;
-    surrealdb.protocol.v1.Value result = 4;
 }
 
 // Variables.


### PR DESCRIPTION
This simplifies the gRPC API such that we're no longer exposing our expression type internals (as much).

`rpc Query(QueryRequest) -> (stream QueryResponse)`: Takes a text query and variables and returns a stream of responses.
`rpc Subscribe(SubscribeRequest) -> (stream SubscribeResponse)`: Takes a text query and variables and returns a stream of live notifications.

`rpc Signup()`, `rpc Signin()`, and `rpc Authenticate()` accept explicit parameters for handling auth.
