### PR TITLE
Add back set, unset, reset, and use methods to the API.

### DIFF
--- a/gen/c/surrealdb/protocol/rpc/v1/rpc.pb-c.c
+++ b/gen/c/surrealdb/protocol/rpc/v1/rpc.pb-c.c
@@ -457,6 +457,366 @@ void   surrealdb__protocol__rpc__v1__authenticate_response__free_unpacked
   assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__authenticate_response__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
+void   surrealdb__protocol__rpc__v1__use_request__init
+                     (Surrealdb__Protocol__Rpc__V1__UseRequest         *message)
+{
+  static const Surrealdb__Protocol__Rpc__V1__UseRequest init_value = SURREALDB__PROTOCOL__RPC__V1__USE_REQUEST__INIT;
+  *message = init_value;
+}
+size_t surrealdb__protocol__rpc__v1__use_request__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__UseRequest *message)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_request__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t surrealdb__protocol__rpc__v1__use_request__pack
+                     (const Surrealdb__Protocol__Rpc__V1__UseRequest *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_request__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t surrealdb__protocol__rpc__v1__use_request__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__UseRequest *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_request__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Surrealdb__Protocol__Rpc__V1__UseRequest *
+       surrealdb__protocol__rpc__v1__use_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Surrealdb__Protocol__Rpc__V1__UseRequest *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__use_request__descriptor,
+                                allocator, len, data);
+}
+void   surrealdb__protocol__rpc__v1__use_request__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__UseRequest *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_request__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   surrealdb__protocol__rpc__v1__use_response__init
+                     (Surrealdb__Protocol__Rpc__V1__UseResponse         *message)
+{
+  static const Surrealdb__Protocol__Rpc__V1__UseResponse init_value = SURREALDB__PROTOCOL__RPC__V1__USE_RESPONSE__INIT;
+  *message = init_value;
+}
+size_t surrealdb__protocol__rpc__v1__use_response__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__UseResponse *message)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_response__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t surrealdb__protocol__rpc__v1__use_response__pack
+                     (const Surrealdb__Protocol__Rpc__V1__UseResponse *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_response__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t surrealdb__protocol__rpc__v1__use_response__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__UseResponse *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_response__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Surrealdb__Protocol__Rpc__V1__UseResponse *
+       surrealdb__protocol__rpc__v1__use_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Surrealdb__Protocol__Rpc__V1__UseResponse *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__use_response__descriptor,
+                                allocator, len, data);
+}
+void   surrealdb__protocol__rpc__v1__use_response__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__UseResponse *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__use_response__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   surrealdb__protocol__rpc__v1__set_request__init
+                     (Surrealdb__Protocol__Rpc__V1__SetRequest         *message)
+{
+  static const Surrealdb__Protocol__Rpc__V1__SetRequest init_value = SURREALDB__PROTOCOL__RPC__V1__SET_REQUEST__INIT;
+  *message = init_value;
+}
+size_t surrealdb__protocol__rpc__v1__set_request__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__SetRequest *message)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_request__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t surrealdb__protocol__rpc__v1__set_request__pack
+                     (const Surrealdb__Protocol__Rpc__V1__SetRequest *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_request__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t surrealdb__protocol__rpc__v1__set_request__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__SetRequest *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_request__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Surrealdb__Protocol__Rpc__V1__SetRequest *
+       surrealdb__protocol__rpc__v1__set_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Surrealdb__Protocol__Rpc__V1__SetRequest *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__set_request__descriptor,
+                                allocator, len, data);
+}
+void   surrealdb__protocol__rpc__v1__set_request__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__SetRequest *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_request__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   surrealdb__protocol__rpc__v1__set_response__init
+                     (Surrealdb__Protocol__Rpc__V1__SetResponse         *message)
+{
+  static const Surrealdb__Protocol__Rpc__V1__SetResponse init_value = SURREALDB__PROTOCOL__RPC__V1__SET_RESPONSE__INIT;
+  *message = init_value;
+}
+size_t surrealdb__protocol__rpc__v1__set_response__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__SetResponse *message)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_response__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t surrealdb__protocol__rpc__v1__set_response__pack
+                     (const Surrealdb__Protocol__Rpc__V1__SetResponse *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_response__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t surrealdb__protocol__rpc__v1__set_response__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__SetResponse *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_response__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Surrealdb__Protocol__Rpc__V1__SetResponse *
+       surrealdb__protocol__rpc__v1__set_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Surrealdb__Protocol__Rpc__V1__SetResponse *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__set_response__descriptor,
+                                allocator, len, data);
+}
+void   surrealdb__protocol__rpc__v1__set_response__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__SetResponse *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__set_response__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   surrealdb__protocol__rpc__v1__unset_request__init
+                     (Surrealdb__Protocol__Rpc__V1__UnsetRequest         *message)
+{
+  static const Surrealdb__Protocol__Rpc__V1__UnsetRequest init_value = SURREALDB__PROTOCOL__RPC__V1__UNSET_REQUEST__INIT;
+  *message = init_value;
+}
+size_t surrealdb__protocol__rpc__v1__unset_request__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest *message)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_request__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t surrealdb__protocol__rpc__v1__unset_request__pack
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_request__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t surrealdb__protocol__rpc__v1__unset_request__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_request__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Surrealdb__Protocol__Rpc__V1__UnsetRequest *
+       surrealdb__protocol__rpc__v1__unset_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Surrealdb__Protocol__Rpc__V1__UnsetRequest *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__unset_request__descriptor,
+                                allocator, len, data);
+}
+void   surrealdb__protocol__rpc__v1__unset_request__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__UnsetRequest *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_request__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   surrealdb__protocol__rpc__v1__unset_response__init
+                     (Surrealdb__Protocol__Rpc__V1__UnsetResponse         *message)
+{
+  static const Surrealdb__Protocol__Rpc__V1__UnsetResponse init_value = SURREALDB__PROTOCOL__RPC__V1__UNSET_RESPONSE__INIT;
+  *message = init_value;
+}
+size_t surrealdb__protocol__rpc__v1__unset_response__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse *message)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_response__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t surrealdb__protocol__rpc__v1__unset_response__pack
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_response__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t surrealdb__protocol__rpc__v1__unset_response__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_response__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Surrealdb__Protocol__Rpc__V1__UnsetResponse *
+       surrealdb__protocol__rpc__v1__unset_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Surrealdb__Protocol__Rpc__V1__UnsetResponse *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__unset_response__descriptor,
+                                allocator, len, data);
+}
+void   surrealdb__protocol__rpc__v1__unset_response__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__UnsetResponse *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__unset_response__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   surrealdb__protocol__rpc__v1__reset_request__init
+                     (Surrealdb__Protocol__Rpc__V1__ResetRequest         *message)
+{
+  static const Surrealdb__Protocol__Rpc__V1__ResetRequest init_value = SURREALDB__PROTOCOL__RPC__V1__RESET_REQUEST__INIT;
+  *message = init_value;
+}
+size_t surrealdb__protocol__rpc__v1__reset_request__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest *message)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_request__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t surrealdb__protocol__rpc__v1__reset_request__pack
+                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_request__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t surrealdb__protocol__rpc__v1__reset_request__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_request__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Surrealdb__Protocol__Rpc__V1__ResetRequest *
+       surrealdb__protocol__rpc__v1__reset_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Surrealdb__Protocol__Rpc__V1__ResetRequest *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__reset_request__descriptor,
+                                allocator, len, data);
+}
+void   surrealdb__protocol__rpc__v1__reset_request__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__ResetRequest *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_request__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   surrealdb__protocol__rpc__v1__reset_response__init
+                     (Surrealdb__Protocol__Rpc__V1__ResetResponse         *message)
+{
+  static const Surrealdb__Protocol__Rpc__V1__ResetResponse init_value = SURREALDB__PROTOCOL__RPC__V1__RESET_RESPONSE__INIT;
+  *message = init_value;
+}
+size_t surrealdb__protocol__rpc__v1__reset_response__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse *message)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_response__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t surrealdb__protocol__rpc__v1__reset_response__pack
+                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_response__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t surrealdb__protocol__rpc__v1__reset_response__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_response__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+Surrealdb__Protocol__Rpc__V1__ResetResponse *
+       surrealdb__protocol__rpc__v1__reset_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (Surrealdb__Protocol__Rpc__V1__ResetResponse *)
+     protobuf_c_message_unpack (&surrealdb__protocol__rpc__v1__reset_response__descriptor,
+                                allocator, len, data);
+}
+void   surrealdb__protocol__rpc__v1__reset_response__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__ResetResponse *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &surrealdb__protocol__rpc__v1__reset_response__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
 void   surrealdb__protocol__rpc__v1__subscribe_request__init
                      (Surrealdb__Protocol__Rpc__V1__SubscribeRequest         *message)
 {
@@ -1495,6 +1855,269 @@ const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__authenticate_resp
   surrealdb__protocol__rpc__v1__authenticate_response__field_indices_by_name,
   1,  surrealdb__protocol__rpc__v1__authenticate_response__number_ranges,
   (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__authenticate_response__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__use_request__field_descriptors[2] =
+{
+  {
+    "namespace",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__UseRequest, namespace_),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "database",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__UseRequest, database),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned surrealdb__protocol__rpc__v1__use_request__field_indices_by_name[] = {
+  1,   /* field[1] = database */
+  0,   /* field[0] = namespace */
+};
+static const ProtobufCIntRange surrealdb__protocol__rpc__v1__use_request__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__use_request__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "surrealdb.protocol.rpc.v1.UseRequest",
+  "UseRequest",
+  "Surrealdb__Protocol__Rpc__V1__UseRequest",
+  "surrealdb.protocol.rpc.v1",
+  sizeof(Surrealdb__Protocol__Rpc__V1__UseRequest),
+  2,
+  surrealdb__protocol__rpc__v1__use_request__field_descriptors,
+  surrealdb__protocol__rpc__v1__use_request__field_indices_by_name,
+  1,  surrealdb__protocol__rpc__v1__use_request__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__use_request__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__use_response__field_descriptors[2] =
+{
+  {
+    "namespace",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__UseResponse, namespace_),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "database",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__UseResponse, database),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned surrealdb__protocol__rpc__v1__use_response__field_indices_by_name[] = {
+  1,   /* field[1] = database */
+  0,   /* field[0] = namespace */
+};
+static const ProtobufCIntRange surrealdb__protocol__rpc__v1__use_response__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__use_response__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "surrealdb.protocol.rpc.v1.UseResponse",
+  "UseResponse",
+  "Surrealdb__Protocol__Rpc__V1__UseResponse",
+  "surrealdb.protocol.rpc.v1",
+  sizeof(Surrealdb__Protocol__Rpc__V1__UseResponse),
+  2,
+  surrealdb__protocol__rpc__v1__use_response__field_descriptors,
+  surrealdb__protocol__rpc__v1__use_response__field_indices_by_name,
+  1,  surrealdb__protocol__rpc__v1__use_response__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__use_response__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__set_request__field_descriptors[2] =
+{
+  {
+    "name",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__SetRequest, name),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "value",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__SetRequest, value),
+    &surrealdb__protocol__v1__value__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned surrealdb__protocol__rpc__v1__set_request__field_indices_by_name[] = {
+  0,   /* field[0] = name */
+  1,   /* field[1] = value */
+};
+static const ProtobufCIntRange surrealdb__protocol__rpc__v1__set_request__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__set_request__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "surrealdb.protocol.rpc.v1.SetRequest",
+  "SetRequest",
+  "Surrealdb__Protocol__Rpc__V1__SetRequest",
+  "surrealdb.protocol.rpc.v1",
+  sizeof(Surrealdb__Protocol__Rpc__V1__SetRequest),
+  2,
+  surrealdb__protocol__rpc__v1__set_request__field_descriptors,
+  surrealdb__protocol__rpc__v1__set_request__field_indices_by_name,
+  1,  surrealdb__protocol__rpc__v1__set_request__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__set_request__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+#define surrealdb__protocol__rpc__v1__set_response__field_descriptors NULL
+#define surrealdb__protocol__rpc__v1__set_response__field_indices_by_name NULL
+#define surrealdb__protocol__rpc__v1__set_response__number_ranges NULL
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__set_response__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "surrealdb.protocol.rpc.v1.SetResponse",
+  "SetResponse",
+  "Surrealdb__Protocol__Rpc__V1__SetResponse",
+  "surrealdb.protocol.rpc.v1",
+  sizeof(Surrealdb__Protocol__Rpc__V1__SetResponse),
+  0,
+  surrealdb__protocol__rpc__v1__set_response__field_descriptors,
+  surrealdb__protocol__rpc__v1__set_response__field_indices_by_name,
+  0,  surrealdb__protocol__rpc__v1__set_response__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__set_response__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__unset_request__field_descriptors[1] =
+{
+  {
+    "name",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_STRING,
+    0,   /* quantifier_offset */
+    offsetof(Surrealdb__Protocol__Rpc__V1__UnsetRequest, name),
+    NULL,
+    &protobuf_c_empty_string,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned surrealdb__protocol__rpc__v1__unset_request__field_indices_by_name[] = {
+  0,   /* field[0] = name */
+};
+static const ProtobufCIntRange surrealdb__protocol__rpc__v1__unset_request__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__unset_request__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "surrealdb.protocol.rpc.v1.UnsetRequest",
+  "UnsetRequest",
+  "Surrealdb__Protocol__Rpc__V1__UnsetRequest",
+  "surrealdb.protocol.rpc.v1",
+  sizeof(Surrealdb__Protocol__Rpc__V1__UnsetRequest),
+  1,
+  surrealdb__protocol__rpc__v1__unset_request__field_descriptors,
+  surrealdb__protocol__rpc__v1__unset_request__field_indices_by_name,
+  1,  surrealdb__protocol__rpc__v1__unset_request__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__unset_request__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+#define surrealdb__protocol__rpc__v1__unset_response__field_descriptors NULL
+#define surrealdb__protocol__rpc__v1__unset_response__field_indices_by_name NULL
+#define surrealdb__protocol__rpc__v1__unset_response__number_ranges NULL
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__unset_response__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "surrealdb.protocol.rpc.v1.UnsetResponse",
+  "UnsetResponse",
+  "Surrealdb__Protocol__Rpc__V1__UnsetResponse",
+  "surrealdb.protocol.rpc.v1",
+  sizeof(Surrealdb__Protocol__Rpc__V1__UnsetResponse),
+  0,
+  surrealdb__protocol__rpc__v1__unset_response__field_descriptors,
+  surrealdb__protocol__rpc__v1__unset_response__field_indices_by_name,
+  0,  surrealdb__protocol__rpc__v1__unset_response__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__unset_response__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+#define surrealdb__protocol__rpc__v1__reset_request__field_descriptors NULL
+#define surrealdb__protocol__rpc__v1__reset_request__field_indices_by_name NULL
+#define surrealdb__protocol__rpc__v1__reset_request__number_ranges NULL
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__reset_request__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "surrealdb.protocol.rpc.v1.ResetRequest",
+  "ResetRequest",
+  "Surrealdb__Protocol__Rpc__V1__ResetRequest",
+  "surrealdb.protocol.rpc.v1",
+  sizeof(Surrealdb__Protocol__Rpc__V1__ResetRequest),
+  0,
+  surrealdb__protocol__rpc__v1__reset_request__field_descriptors,
+  surrealdb__protocol__rpc__v1__reset_request__field_indices_by_name,
+  0,  surrealdb__protocol__rpc__v1__reset_request__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__reset_request__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+#define surrealdb__protocol__rpc__v1__reset_response__field_descriptors NULL
+#define surrealdb__protocol__rpc__v1__reset_response__field_indices_by_name NULL
+#define surrealdb__protocol__rpc__v1__reset_response__number_ranges NULL
+const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__reset_response__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "surrealdb.protocol.rpc.v1.ResetResponse",
+  "ResetResponse",
+  "Surrealdb__Protocol__Rpc__V1__ResetResponse",
+  "surrealdb.protocol.rpc.v1",
+  sizeof(Surrealdb__Protocol__Rpc__V1__ResetResponse),
+  0,
+  surrealdb__protocol__rpc__v1__reset_response__field_descriptors,
+  surrealdb__protocol__rpc__v1__reset_response__field_indices_by_name,
+  0,  surrealdb__protocol__rpc__v1__reset_response__number_ranges,
+  (ProtobufCMessageInit) surrealdb__protocol__rpc__v1__reset_response__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
 static const ProtobufCFieldDescriptor surrealdb__protocol__rpc__v1__subscribe_request__field_descriptors[2] =
@@ -2568,23 +3191,31 @@ const ProtobufCEnumDescriptor surrealdb__protocol__rpc__v1__action__descriptor =
   surrealdb__protocol__rpc__v1__action__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCMethodDescriptor surrealdb__protocol__rpc__v1__surreal_dbservice__method_descriptors[7] =
+static const ProtobufCMethodDescriptor surrealdb__protocol__rpc__v1__surreal_dbservice__method_descriptors[11] =
 {
   { "Health", &surrealdb__protocol__rpc__v1__health_request__descriptor, &surrealdb__protocol__rpc__v1__health_response__descriptor },
   { "Version", &surrealdb__protocol__rpc__v1__version_request__descriptor, &surrealdb__protocol__rpc__v1__version_response__descriptor },
   { "Signup", &surrealdb__protocol__rpc__v1__signup_request__descriptor, &surrealdb__protocol__rpc__v1__signup_response__descriptor },
   { "Signin", &surrealdb__protocol__rpc__v1__signin_request__descriptor, &surrealdb__protocol__rpc__v1__signin_response__descriptor },
   { "Authenticate", &surrealdb__protocol__rpc__v1__authenticate_request__descriptor, &surrealdb__protocol__rpc__v1__authenticate_response__descriptor },
+  { "Use", &surrealdb__protocol__rpc__v1__use_request__descriptor, &surrealdb__protocol__rpc__v1__use_response__descriptor },
+  { "Set", &surrealdb__protocol__rpc__v1__set_request__descriptor, &surrealdb__protocol__rpc__v1__set_response__descriptor },
+  { "Unset", &surrealdb__protocol__rpc__v1__unset_request__descriptor, &surrealdb__protocol__rpc__v1__unset_response__descriptor },
+  { "Reset", &surrealdb__protocol__rpc__v1__reset_request__descriptor, &surrealdb__protocol__rpc__v1__reset_response__descriptor },
   { "Query", &surrealdb__protocol__rpc__v1__query_request__descriptor, &surrealdb__protocol__rpc__v1__query_response__descriptor },
   { "Subscribe", &surrealdb__protocol__rpc__v1__subscribe_request__descriptor, &surrealdb__protocol__rpc__v1__subscribe_response__descriptor },
 };
 const unsigned surrealdb__protocol__rpc__v1__surreal_dbservice__method_indices_by_name[] = {
   4,        /* Authenticate */
   0,        /* Health */
-  5,        /* Query */
+  9,        /* Query */
+  8,        /* Reset */
+  6,        /* Set */
   3,        /* Signin */
   2,        /* Signup */
-  6,        /* Subscribe */
+  10,        /* Subscribe */
+  7,        /* Unset */
+  5,        /* Use */
   1         /* Version */
 };
 const ProtobufCServiceDescriptor surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor =
@@ -2594,7 +3225,7 @@ const ProtobufCServiceDescriptor surrealdb__protocol__rpc__v1__surreal_dbservice
   "SurrealDBService",
   "Surrealdb__Protocol__Rpc__V1__SurrealDBService",
   "surrealdb.protocol.rpc.v1",
-  7,
+  11,
   surrealdb__protocol__rpc__v1__surreal_dbservice__method_descriptors,
   surrealdb__protocol__rpc__v1__surreal_dbservice__method_indices_by_name
 };
@@ -2638,13 +3269,45 @@ void surrealdb__protocol__rpc__v1__surreal_dbservice__authenticate(ProtobufCServ
   assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
   service->invoke(service, 4, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
+void surrealdb__protocol__rpc__v1__surreal_dbservice__use(ProtobufCService *service,
+                                                          const Surrealdb__Protocol__Rpc__V1__UseRequest *input,
+                                                          Surrealdb__Protocol__Rpc__V1__UseResponse_Closure closure,
+                                                          void *closure_data)
+{
+  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
+  service->invoke(service, 5, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+}
+void surrealdb__protocol__rpc__v1__surreal_dbservice__set(ProtobufCService *service,
+                                                          const Surrealdb__Protocol__Rpc__V1__SetRequest *input,
+                                                          Surrealdb__Protocol__Rpc__V1__SetResponse_Closure closure,
+                                                          void *closure_data)
+{
+  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
+  service->invoke(service, 6, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+}
+void surrealdb__protocol__rpc__v1__surreal_dbservice__unset(ProtobufCService *service,
+                                                            const Surrealdb__Protocol__Rpc__V1__UnsetRequest *input,
+                                                            Surrealdb__Protocol__Rpc__V1__UnsetResponse_Closure closure,
+                                                            void *closure_data)
+{
+  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
+  service->invoke(service, 7, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+}
+void surrealdb__protocol__rpc__v1__surreal_dbservice__reset(ProtobufCService *service,
+                                                            const Surrealdb__Protocol__Rpc__V1__ResetRequest *input,
+                                                            Surrealdb__Protocol__Rpc__V1__ResetResponse_Closure closure,
+                                                            void *closure_data)
+{
+  assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
+  service->invoke(service, 8, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+}
 void surrealdb__protocol__rpc__v1__surreal_dbservice__query(ProtobufCService *service,
                                                             const Surrealdb__Protocol__Rpc__V1__QueryRequest *input,
                                                             Surrealdb__Protocol__Rpc__V1__QueryResponse_Closure closure,
                                                             void *closure_data)
 {
   assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 5, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+  service->invoke(service, 9, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
 void surrealdb__protocol__rpc__v1__surreal_dbservice__subscribe(ProtobufCService *service,
                                                                 const Surrealdb__Protocol__Rpc__V1__SubscribeRequest *input,
@@ -2652,7 +3315,7 @@ void surrealdb__protocol__rpc__v1__surreal_dbservice__subscribe(ProtobufCService
                                                                 void *closure_data)
 {
   assert(service->descriptor == &surrealdb__protocol__rpc__v1__surreal_dbservice__descriptor);
-  service->invoke(service, 6, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
+  service->invoke(service, 10, (const ProtobufCMessage *) input, (ProtobufCClosure) closure, closure_data);
 }
 void surrealdb__protocol__rpc__v1__surreal_dbservice__init (Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
                                                             Surrealdb__Protocol__Rpc__V1__SurrealDBService_ServiceDestroy destroy)

--- a/gen/c/surrealdb/protocol/rpc/v1/rpc.pb-c.h
+++ b/gen/c/surrealdb/protocol/rpc/v1/rpc.pb-c.h
@@ -28,6 +28,14 @@ typedef struct Surrealdb__Protocol__Rpc__V1__SigninRequest Surrealdb__Protocol__
 typedef struct Surrealdb__Protocol__Rpc__V1__SigninResponse Surrealdb__Protocol__Rpc__V1__SigninResponse;
 typedef struct Surrealdb__Protocol__Rpc__V1__AuthenticateRequest Surrealdb__Protocol__Rpc__V1__AuthenticateRequest;
 typedef struct Surrealdb__Protocol__Rpc__V1__AuthenticateResponse Surrealdb__Protocol__Rpc__V1__AuthenticateResponse;
+typedef struct Surrealdb__Protocol__Rpc__V1__UseRequest Surrealdb__Protocol__Rpc__V1__UseRequest;
+typedef struct Surrealdb__Protocol__Rpc__V1__UseResponse Surrealdb__Protocol__Rpc__V1__UseResponse;
+typedef struct Surrealdb__Protocol__Rpc__V1__SetRequest Surrealdb__Protocol__Rpc__V1__SetRequest;
+typedef struct Surrealdb__Protocol__Rpc__V1__SetResponse Surrealdb__Protocol__Rpc__V1__SetResponse;
+typedef struct Surrealdb__Protocol__Rpc__V1__UnsetRequest Surrealdb__Protocol__Rpc__V1__UnsetRequest;
+typedef struct Surrealdb__Protocol__Rpc__V1__UnsetResponse Surrealdb__Protocol__Rpc__V1__UnsetResponse;
+typedef struct Surrealdb__Protocol__Rpc__V1__ResetRequest Surrealdb__Protocol__Rpc__V1__ResetRequest;
+typedef struct Surrealdb__Protocol__Rpc__V1__ResetResponse Surrealdb__Protocol__Rpc__V1__ResetResponse;
 typedef struct Surrealdb__Protocol__Rpc__V1__SubscribeRequest Surrealdb__Protocol__Rpc__V1__SubscribeRequest;
 typedef struct Surrealdb__Protocol__Rpc__V1__SubscribeResponse Surrealdb__Protocol__Rpc__V1__SubscribeResponse;
 typedef struct Surrealdb__Protocol__Rpc__V1__Notification Surrealdb__Protocol__Rpc__V1__Notification;
@@ -190,6 +198,132 @@ struct  Surrealdb__Protocol__Rpc__V1__AuthenticateResponse
 #define SURREALDB__PROTOCOL__RPC__V1__AUTHENTICATE_RESPONSE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__authenticate_response__descriptor) \
 , NULL }
+
+
+/*
+ * Request to use a namespace and database.
+ */
+struct  Surrealdb__Protocol__Rpc__V1__UseRequest
+{
+  ProtobufCMessage base;
+  /*
+   * The namespace to use.
+   * An empty namespace will unset the current namespace.
+   */
+  char *namespace_;
+  /*
+   * The database to use.
+   * An empty database will unset the current database.
+   */
+  char *database;
+};
+#define SURREALDB__PROTOCOL__RPC__V1__USE_REQUEST__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__use_request__descriptor) \
+, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
+
+
+/*
+ * Response to a use request.
+ */
+struct  Surrealdb__Protocol__Rpc__V1__UseResponse
+{
+  ProtobufCMessage base;
+  /*
+   * The namespace that is now in use.
+   */
+  char *namespace_;
+  /*
+   * The database that is now in use.
+   */
+  char *database;
+};
+#define SURREALDB__PROTOCOL__RPC__V1__USE_RESPONSE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__use_response__descriptor) \
+, (char *)protobuf_c_empty_string, (char *)protobuf_c_empty_string }
+
+
+/*
+ * Request to set a global variable for the current session.
+ */
+struct  Surrealdb__Protocol__Rpc__V1__SetRequest
+{
+  ProtobufCMessage base;
+  /*
+   * The name of the variable to set.
+   */
+  char *name;
+  /*
+   * The value to set the variable to.
+   */
+  Surrealdb__Protocol__V1__Value *value;
+};
+#define SURREALDB__PROTOCOL__RPC__V1__SET_REQUEST__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__set_request__descriptor) \
+, (char *)protobuf_c_empty_string, NULL }
+
+
+/*
+ * Response to a set request.
+ */
+struct  Surrealdb__Protocol__Rpc__V1__SetResponse
+{
+  ProtobufCMessage base;
+};
+#define SURREALDB__PROTOCOL__RPC__V1__SET_RESPONSE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__set_response__descriptor) \
+ }
+
+
+/*
+ * Request to unset a global variable for the current session.
+ */
+struct  Surrealdb__Protocol__Rpc__V1__UnsetRequest
+{
+  ProtobufCMessage base;
+  /*
+   * The name of the variable to unset.
+   */
+  char *name;
+};
+#define SURREALDB__PROTOCOL__RPC__V1__UNSET_REQUEST__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__unset_request__descriptor) \
+, (char *)protobuf_c_empty_string }
+
+
+/*
+ * Response to an unset request.
+ */
+struct  Surrealdb__Protocol__Rpc__V1__UnsetResponse
+{
+  ProtobufCMessage base;
+};
+#define SURREALDB__PROTOCOL__RPC__V1__UNSET_RESPONSE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__unset_response__descriptor) \
+ }
+
+
+/*
+ * Request to reset all global variables for the current session.
+ */
+struct  Surrealdb__Protocol__Rpc__V1__ResetRequest
+{
+  ProtobufCMessage base;
+};
+#define SURREALDB__PROTOCOL__RPC__V1__RESET_REQUEST__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__reset_request__descriptor) \
+ }
+
+
+/*
+ * Response to a reset request.
+ */
+struct  Surrealdb__Protocol__Rpc__V1__ResetResponse
+{
+  ProtobufCMessage base;
+};
+#define SURREALDB__PROTOCOL__RPC__V1__RESET_RESPONSE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&surrealdb__protocol__rpc__v1__reset_response__descriptor) \
+ }
 
 
 /*
@@ -690,6 +824,158 @@ Surrealdb__Protocol__Rpc__V1__AuthenticateResponse *
 void   surrealdb__protocol__rpc__v1__authenticate_response__free_unpacked
                      (Surrealdb__Protocol__Rpc__V1__AuthenticateResponse *message,
                       ProtobufCAllocator *allocator);
+/* Surrealdb__Protocol__Rpc__V1__UseRequest methods */
+void   surrealdb__protocol__rpc__v1__use_request__init
+                     (Surrealdb__Protocol__Rpc__V1__UseRequest         *message);
+size_t surrealdb__protocol__rpc__v1__use_request__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__UseRequest   *message);
+size_t surrealdb__protocol__rpc__v1__use_request__pack
+                     (const Surrealdb__Protocol__Rpc__V1__UseRequest   *message,
+                      uint8_t             *out);
+size_t surrealdb__protocol__rpc__v1__use_request__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__UseRequest   *message,
+                      ProtobufCBuffer     *buffer);
+Surrealdb__Protocol__Rpc__V1__UseRequest *
+       surrealdb__protocol__rpc__v1__use_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   surrealdb__protocol__rpc__v1__use_request__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__UseRequest *message,
+                      ProtobufCAllocator *allocator);
+/* Surrealdb__Protocol__Rpc__V1__UseResponse methods */
+void   surrealdb__protocol__rpc__v1__use_response__init
+                     (Surrealdb__Protocol__Rpc__V1__UseResponse         *message);
+size_t surrealdb__protocol__rpc__v1__use_response__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__UseResponse   *message);
+size_t surrealdb__protocol__rpc__v1__use_response__pack
+                     (const Surrealdb__Protocol__Rpc__V1__UseResponse   *message,
+                      uint8_t             *out);
+size_t surrealdb__protocol__rpc__v1__use_response__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__UseResponse   *message,
+                      ProtobufCBuffer     *buffer);
+Surrealdb__Protocol__Rpc__V1__UseResponse *
+       surrealdb__protocol__rpc__v1__use_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   surrealdb__protocol__rpc__v1__use_response__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__UseResponse *message,
+                      ProtobufCAllocator *allocator);
+/* Surrealdb__Protocol__Rpc__V1__SetRequest methods */
+void   surrealdb__protocol__rpc__v1__set_request__init
+                     (Surrealdb__Protocol__Rpc__V1__SetRequest         *message);
+size_t surrealdb__protocol__rpc__v1__set_request__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__SetRequest   *message);
+size_t surrealdb__protocol__rpc__v1__set_request__pack
+                     (const Surrealdb__Protocol__Rpc__V1__SetRequest   *message,
+                      uint8_t             *out);
+size_t surrealdb__protocol__rpc__v1__set_request__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__SetRequest   *message,
+                      ProtobufCBuffer     *buffer);
+Surrealdb__Protocol__Rpc__V1__SetRequest *
+       surrealdb__protocol__rpc__v1__set_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   surrealdb__protocol__rpc__v1__set_request__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__SetRequest *message,
+                      ProtobufCAllocator *allocator);
+/* Surrealdb__Protocol__Rpc__V1__SetResponse methods */
+void   surrealdb__protocol__rpc__v1__set_response__init
+                     (Surrealdb__Protocol__Rpc__V1__SetResponse         *message);
+size_t surrealdb__protocol__rpc__v1__set_response__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__SetResponse   *message);
+size_t surrealdb__protocol__rpc__v1__set_response__pack
+                     (const Surrealdb__Protocol__Rpc__V1__SetResponse   *message,
+                      uint8_t             *out);
+size_t surrealdb__protocol__rpc__v1__set_response__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__SetResponse   *message,
+                      ProtobufCBuffer     *buffer);
+Surrealdb__Protocol__Rpc__V1__SetResponse *
+       surrealdb__protocol__rpc__v1__set_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   surrealdb__protocol__rpc__v1__set_response__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__SetResponse *message,
+                      ProtobufCAllocator *allocator);
+/* Surrealdb__Protocol__Rpc__V1__UnsetRequest methods */
+void   surrealdb__protocol__rpc__v1__unset_request__init
+                     (Surrealdb__Protocol__Rpc__V1__UnsetRequest         *message);
+size_t surrealdb__protocol__rpc__v1__unset_request__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest   *message);
+size_t surrealdb__protocol__rpc__v1__unset_request__pack
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest   *message,
+                      uint8_t             *out);
+size_t surrealdb__protocol__rpc__v1__unset_request__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetRequest   *message,
+                      ProtobufCBuffer     *buffer);
+Surrealdb__Protocol__Rpc__V1__UnsetRequest *
+       surrealdb__protocol__rpc__v1__unset_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   surrealdb__protocol__rpc__v1__unset_request__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__UnsetRequest *message,
+                      ProtobufCAllocator *allocator);
+/* Surrealdb__Protocol__Rpc__V1__UnsetResponse methods */
+void   surrealdb__protocol__rpc__v1__unset_response__init
+                     (Surrealdb__Protocol__Rpc__V1__UnsetResponse         *message);
+size_t surrealdb__protocol__rpc__v1__unset_response__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse   *message);
+size_t surrealdb__protocol__rpc__v1__unset_response__pack
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse   *message,
+                      uint8_t             *out);
+size_t surrealdb__protocol__rpc__v1__unset_response__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__UnsetResponse   *message,
+                      ProtobufCBuffer     *buffer);
+Surrealdb__Protocol__Rpc__V1__UnsetResponse *
+       surrealdb__protocol__rpc__v1__unset_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   surrealdb__protocol__rpc__v1__unset_response__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__UnsetResponse *message,
+                      ProtobufCAllocator *allocator);
+/* Surrealdb__Protocol__Rpc__V1__ResetRequest methods */
+void   surrealdb__protocol__rpc__v1__reset_request__init
+                     (Surrealdb__Protocol__Rpc__V1__ResetRequest         *message);
+size_t surrealdb__protocol__rpc__v1__reset_request__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest   *message);
+size_t surrealdb__protocol__rpc__v1__reset_request__pack
+                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest   *message,
+                      uint8_t             *out);
+size_t surrealdb__protocol__rpc__v1__reset_request__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__ResetRequest   *message,
+                      ProtobufCBuffer     *buffer);
+Surrealdb__Protocol__Rpc__V1__ResetRequest *
+       surrealdb__protocol__rpc__v1__reset_request__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   surrealdb__protocol__rpc__v1__reset_request__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__ResetRequest *message,
+                      ProtobufCAllocator *allocator);
+/* Surrealdb__Protocol__Rpc__V1__ResetResponse methods */
+void   surrealdb__protocol__rpc__v1__reset_response__init
+                     (Surrealdb__Protocol__Rpc__V1__ResetResponse         *message);
+size_t surrealdb__protocol__rpc__v1__reset_response__get_packed_size
+                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse   *message);
+size_t surrealdb__protocol__rpc__v1__reset_response__pack
+                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse   *message,
+                      uint8_t             *out);
+size_t surrealdb__protocol__rpc__v1__reset_response__pack_to_buffer
+                     (const Surrealdb__Protocol__Rpc__V1__ResetResponse   *message,
+                      ProtobufCBuffer     *buffer);
+Surrealdb__Protocol__Rpc__V1__ResetResponse *
+       surrealdb__protocol__rpc__v1__reset_response__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   surrealdb__protocol__rpc__v1__reset_response__free_unpacked
+                     (Surrealdb__Protocol__Rpc__V1__ResetResponse *message,
+                      ProtobufCAllocator *allocator);
 /* Surrealdb__Protocol__Rpc__V1__SubscribeRequest methods */
 void   surrealdb__protocol__rpc__v1__subscribe_request__init
                      (Surrealdb__Protocol__Rpc__V1__SubscribeRequest         *message);
@@ -1010,6 +1296,30 @@ typedef void (*Surrealdb__Protocol__Rpc__V1__AuthenticateRequest_Closure)
 typedef void (*Surrealdb__Protocol__Rpc__V1__AuthenticateResponse_Closure)
                  (const Surrealdb__Protocol__Rpc__V1__AuthenticateResponse *message,
                   void *closure_data);
+typedef void (*Surrealdb__Protocol__Rpc__V1__UseRequest_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__UseRequest *message,
+                  void *closure_data);
+typedef void (*Surrealdb__Protocol__Rpc__V1__UseResponse_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__UseResponse *message,
+                  void *closure_data);
+typedef void (*Surrealdb__Protocol__Rpc__V1__SetRequest_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__SetRequest *message,
+                  void *closure_data);
+typedef void (*Surrealdb__Protocol__Rpc__V1__SetResponse_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__SetResponse *message,
+                  void *closure_data);
+typedef void (*Surrealdb__Protocol__Rpc__V1__UnsetRequest_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__UnsetRequest *message,
+                  void *closure_data);
+typedef void (*Surrealdb__Protocol__Rpc__V1__UnsetResponse_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__UnsetResponse *message,
+                  void *closure_data);
+typedef void (*Surrealdb__Protocol__Rpc__V1__ResetRequest_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__ResetRequest *message,
+                  void *closure_data);
+typedef void (*Surrealdb__Protocol__Rpc__V1__ResetResponse_Closure)
+                 (const Surrealdb__Protocol__Rpc__V1__ResetResponse *message,
+                  void *closure_data);
 typedef void (*Surrealdb__Protocol__Rpc__V1__SubscribeRequest_Closure)
                  (const Surrealdb__Protocol__Rpc__V1__SubscribeRequest *message,
                   void *closure_data);
@@ -1085,6 +1395,22 @@ struct Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service
                        const Surrealdb__Protocol__Rpc__V1__AuthenticateRequest *input,
                        Surrealdb__Protocol__Rpc__V1__AuthenticateResponse_Closure closure,
                        void *closure_data);
+  void (*use)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
+              const Surrealdb__Protocol__Rpc__V1__UseRequest *input,
+              Surrealdb__Protocol__Rpc__V1__UseResponse_Closure closure,
+              void *closure_data);
+  void (*set)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
+              const Surrealdb__Protocol__Rpc__V1__SetRequest *input,
+              Surrealdb__Protocol__Rpc__V1__SetResponse_Closure closure,
+              void *closure_data);
+  void (*unset)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
+                const Surrealdb__Protocol__Rpc__V1__UnsetRequest *input,
+                Surrealdb__Protocol__Rpc__V1__UnsetResponse_Closure closure,
+                void *closure_data);
+  void (*reset)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
+                const Surrealdb__Protocol__Rpc__V1__ResetRequest *input,
+                Surrealdb__Protocol__Rpc__V1__ResetResponse_Closure closure,
+                void *closure_data);
   void (*query)(Surrealdb__Protocol__Rpc__V1__SurrealDBService_Service *service,
                 const Surrealdb__Protocol__Rpc__V1__QueryRequest *input,
                 Surrealdb__Protocol__Rpc__V1__QueryResponse_Closure closure,
@@ -1106,6 +1432,10 @@ void surrealdb__protocol__rpc__v1__surreal_dbservice__init (Surrealdb__Protocol_
       function_prefix__ ## signup,\
       function_prefix__ ## signin,\
       function_prefix__ ## authenticate,\
+      function_prefix__ ## use,\
+      function_prefix__ ## set,\
+      function_prefix__ ## unset,\
+      function_prefix__ ## reset,\
       function_prefix__ ## query,\
       function_prefix__ ## subscribe  }
 void surrealdb__protocol__rpc__v1__surreal_dbservice__health(ProtobufCService *service,
@@ -1128,6 +1458,22 @@ void surrealdb__protocol__rpc__v1__surreal_dbservice__authenticate(ProtobufCServ
                                                                    const Surrealdb__Protocol__Rpc__V1__AuthenticateRequest *input,
                                                                    Surrealdb__Protocol__Rpc__V1__AuthenticateResponse_Closure closure,
                                                                    void *closure_data);
+void surrealdb__protocol__rpc__v1__surreal_dbservice__use(ProtobufCService *service,
+                                                          const Surrealdb__Protocol__Rpc__V1__UseRequest *input,
+                                                          Surrealdb__Protocol__Rpc__V1__UseResponse_Closure closure,
+                                                          void *closure_data);
+void surrealdb__protocol__rpc__v1__surreal_dbservice__set(ProtobufCService *service,
+                                                          const Surrealdb__Protocol__Rpc__V1__SetRequest *input,
+                                                          Surrealdb__Protocol__Rpc__V1__SetResponse_Closure closure,
+                                                          void *closure_data);
+void surrealdb__protocol__rpc__v1__surreal_dbservice__unset(ProtobufCService *service,
+                                                            const Surrealdb__Protocol__Rpc__V1__UnsetRequest *input,
+                                                            Surrealdb__Protocol__Rpc__V1__UnsetResponse_Closure closure,
+                                                            void *closure_data);
+void surrealdb__protocol__rpc__v1__surreal_dbservice__reset(ProtobufCService *service,
+                                                            const Surrealdb__Protocol__Rpc__V1__ResetRequest *input,
+                                                            Surrealdb__Protocol__Rpc__V1__ResetResponse_Closure closure,
+                                                            void *closure_data);
 void surrealdb__protocol__rpc__v1__surreal_dbservice__query(ProtobufCService *service,
                                                             const Surrealdb__Protocol__Rpc__V1__QueryRequest *input,
                                                             Surrealdb__Protocol__Rpc__V1__QueryResponse_Closure closure,
@@ -1150,6 +1496,14 @@ extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__signin_req
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__signin_response__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__authenticate_request__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__authenticate_response__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__use_request__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__use_response__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__set_request__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__set_response__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__unset_request__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__unset_response__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__reset_request__descriptor;
+extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__reset_response__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__subscribe_request__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__subscribe_response__descriptor;
 extern const ProtobufCMessageDescriptor surrealdb__protocol__rpc__v1__notification__descriptor;

--- a/gen/rust/proto/surrealdb.protocol.rpc.v1.rs
+++ b/gen/rust/proto/surrealdb.protocol.rpc.v1.rs
@@ -110,6 +110,101 @@ impl ::prost::Name for AuthenticateResponse {
 const NAME: &'static str = "AuthenticateResponse";
 const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
 fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.AuthenticateResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.AuthenticateResponse".into() }}
+/// Request to use a namespace and database.
+#[derive(serde::Deserialize,serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UseRequest {
+    /// The namespace to use.
+    /// An empty namespace will unset the current namespace.
+    #[prost(string, tag="1")]
+    pub namespace: ::prost::alloc::string::String,
+    /// The database to use.
+    /// An empty database will unset the current database.
+    #[prost(string, tag="2")]
+    pub database: ::prost::alloc::string::String,
+}
+impl ::prost::Name for UseRequest {
+const NAME: &'static str = "UseRequest";
+const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UseRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UseRequest".into() }}
+/// Response to a use request.
+#[derive(serde::Deserialize,serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UseResponse {
+    /// The namespace that is now in use.
+    #[prost(string, tag="1")]
+    pub namespace: ::prost::alloc::string::String,
+    /// The database that is now in use.
+    #[prost(string, tag="2")]
+    pub database: ::prost::alloc::string::String,
+}
+impl ::prost::Name for UseResponse {
+const NAME: &'static str = "UseResponse";
+const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UseResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UseResponse".into() }}
+/// Request to set a global variable for the current session.
+#[derive(serde::Deserialize,serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetRequest {
+    /// The name of the variable to set.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// The value to set the variable to.
+    #[prost(message, optional, tag="2")]
+    pub value: ::core::option::Option<super::super::v1::Value>,
+}
+impl ::prost::Name for SetRequest {
+const NAME: &'static str = "SetRequest";
+const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.SetRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.SetRequest".into() }}
+/// Response to a set request.
+#[derive(serde::Deserialize,serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct SetResponse {
+}
+impl ::prost::Name for SetResponse {
+const NAME: &'static str = "SetResponse";
+const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.SetResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.SetResponse".into() }}
+/// Request to unset a global variable for the current session.
+#[derive(serde::Deserialize,serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnsetRequest {
+    /// The name of the variable to unset.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+}
+impl ::prost::Name for UnsetRequest {
+const NAME: &'static str = "UnsetRequest";
+const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UnsetRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UnsetRequest".into() }}
+/// Response to an unset request.
+#[derive(serde::Deserialize,serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct UnsetResponse {
+}
+impl ::prost::Name for UnsetResponse {
+const NAME: &'static str = "UnsetResponse";
+const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.UnsetResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.UnsetResponse".into() }}
+/// Request to reset all global variables for the current session.
+#[derive(serde::Deserialize,serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct ResetRequest {
+}
+impl ::prost::Name for ResetRequest {
+const NAME: &'static str = "ResetRequest";
+const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.ResetRequest".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.ResetRequest".into() }}
+/// Response to a reset request.
+#[derive(serde::Deserialize,serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct ResetResponse {
+}
+impl ::prost::Name for ResetResponse {
+const NAME: &'static str = "ResetResponse";
+const PACKAGE: &'static str = "surrealdb.protocol.rpc.v1";
+fn full_name() -> ::prost::alloc::string::String { "surrealdb.protocol.rpc.v1.ResetResponse".into() }fn type_url() -> ::prost::alloc::string::String { "/surrealdb.protocol.rpc.v1.ResetResponse".into() }}
 /// Request to issue a live query.
 #[derive(serde::Deserialize,serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/gen/rust/proto/surrealdb.protocol.rpc.v1.tonic.rs
+++ b/gen/rust/proto/surrealdb.protocol.rpc.v1.tonic.rs
@@ -226,6 +226,104 @@ pub mod surreal_db_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn r#use(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UseRequest>,
+        ) -> std::result::Result<tonic::Response<super::UseResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Use",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("surrealdb.protocol.rpc.v1.SurrealDBService", "Use"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn set(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SetRequest>,
+        ) -> std::result::Result<tonic::Response<super::SetResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Set",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("surrealdb.protocol.rpc.v1.SurrealDBService", "Set"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn unset(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UnsetRequest>,
+        ) -> std::result::Result<tonic::Response<super::UnsetResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Unset",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "surrealdb.protocol.rpc.v1.SurrealDBService",
+                        "Unset",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn reset(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ResetRequest>,
+        ) -> std::result::Result<tonic::Response<super::ResetResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Reset",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "surrealdb.protocol.rpc.v1.SurrealDBService",
+                        "Reset",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn query(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryRequest>,
@@ -322,6 +420,22 @@ pub mod surreal_db_service_server {
             tonic::Response<super::AuthenticateResponse>,
             tonic::Status,
         >;
+        async fn r#use(
+            &self,
+            request: tonic::Request<super::UseRequest>,
+        ) -> std::result::Result<tonic::Response<super::UseResponse>, tonic::Status>;
+        async fn set(
+            &self,
+            request: tonic::Request<super::SetRequest>,
+        ) -> std::result::Result<tonic::Response<super::SetResponse>, tonic::Status>;
+        async fn unset(
+            &self,
+            request: tonic::Request<super::UnsetRequest>,
+        ) -> std::result::Result<tonic::Response<super::UnsetResponse>, tonic::Status>;
+        async fn reset(
+            &self,
+            request: tonic::Request<super::ResetRequest>,
+        ) -> std::result::Result<tonic::Response<super::ResetResponse>, tonic::Status>;
         /// Server streaming response type for the Query method.
         type QueryStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::QueryResponse, tonic::Status>,
@@ -629,6 +743,182 @@ pub mod surreal_db_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = AuthenticateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Use" => {
+                    #[allow(non_camel_case_types)]
+                    struct UseSvc<T: SurrealDbService>(pub Arc<T>);
+                    impl<
+                        T: SurrealDbService,
+                    > tonic::server::UnaryService<super::UseRequest> for UseSvc<T> {
+                        type Response = super::UseResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UseRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as SurrealDbService>::r#use(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = UseSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Set" => {
+                    #[allow(non_camel_case_types)]
+                    struct SetSvc<T: SurrealDbService>(pub Arc<T>);
+                    impl<
+                        T: SurrealDbService,
+                    > tonic::server::UnaryService<super::SetRequest> for SetSvc<T> {
+                        type Response = super::SetResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SetRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as SurrealDbService>::set(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = SetSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Unset" => {
+                    #[allow(non_camel_case_types)]
+                    struct UnsetSvc<T: SurrealDbService>(pub Arc<T>);
+                    impl<
+                        T: SurrealDbService,
+                    > tonic::server::UnaryService<super::UnsetRequest> for UnsetSvc<T> {
+                        type Response = super::UnsetResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UnsetRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as SurrealDbService>::unset(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = UnsetSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/surrealdb.protocol.rpc.v1.SurrealDBService/Reset" => {
+                    #[allow(non_camel_case_types)]
+                    struct ResetSvc<T: SurrealDbService>(pub Arc<T>);
+                    impl<
+                        T: SurrealDbService,
+                    > tonic::server::UnaryService<super::ResetRequest> for ResetSvc<T> {
+                        type Response = super::ResetResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ResetRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as SurrealDbService>::reset(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ResetSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/gen/ts/surrealdb/protocol/rpc/v1/rpc.ts
+++ b/gen/ts/surrealdb/protocol/rpc/v1/rpc.ts
@@ -116,6 +116,58 @@ export interface AuthenticateResponse {
   value: Value | undefined;
 }
 
+/** Request to use a namespace and database. */
+export interface UseRequest {
+  /**
+   * The namespace to use.
+   * An empty namespace will unset the current namespace.
+   */
+  namespace: string;
+  /**
+   * The database to use.
+   * An empty database will unset the current database.
+   */
+  database: string;
+}
+
+/** Response to a use request. */
+export interface UseResponse {
+  /** The namespace that is now in use. */
+  namespace: string;
+  /** The database that is now in use. */
+  database: string;
+}
+
+/** Request to set a global variable for the current session. */
+export interface SetRequest {
+  /** The name of the variable to set. */
+  name: string;
+  /** The value to set the variable to. */
+  value: Value | undefined;
+}
+
+/** Response to a set request. */
+export interface SetResponse {
+}
+
+/** Request to unset a global variable for the current session. */
+export interface UnsetRequest {
+  /** The name of the variable to unset. */
+  name: string;
+}
+
+/** Response to an unset request. */
+export interface UnsetResponse {
+}
+
+/** Request to reset all global variables for the current session. */
+export interface ResetRequest {
+}
+
+/** Response to a reset request. */
+export interface ResetResponse {
+}
+
 /** Request to issue a live query. */
 export interface SubscribeRequest {
   query: string;
@@ -855,6 +907,464 @@ export const AuthenticateResponse: MessageFns<AuthenticateResponse> = {
   fromPartial<I extends Exact<DeepPartial<AuthenticateResponse>, I>>(object: I): AuthenticateResponse {
     const message = createBaseAuthenticateResponse();
     message.value = (object.value !== undefined && object.value !== null) ? Value.fromPartial(object.value) : undefined;
+    return message;
+  },
+};
+
+function createBaseUseRequest(): UseRequest {
+  return { namespace: "", database: "" };
+}
+
+export const UseRequest: MessageFns<UseRequest> = {
+  encode(message: UseRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.namespace !== "") {
+      writer.uint32(10).string(message.namespace);
+    }
+    if (message.database !== "") {
+      writer.uint32(18).string(message.database);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UseRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUseRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.namespace = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.database = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UseRequest {
+    return {
+      namespace: isSet(object.namespace) ? globalThis.String(object.namespace) : "",
+      database: isSet(object.database) ? globalThis.String(object.database) : "",
+    };
+  },
+
+  toJSON(message: UseRequest): unknown {
+    const obj: any = {};
+    if (message.namespace !== "") {
+      obj.namespace = message.namespace;
+    }
+    if (message.database !== "") {
+      obj.database = message.database;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UseRequest>, I>>(base?: I): UseRequest {
+    return UseRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UseRequest>, I>>(object: I): UseRequest {
+    const message = createBaseUseRequest();
+    message.namespace = object.namespace ?? "";
+    message.database = object.database ?? "";
+    return message;
+  },
+};
+
+function createBaseUseResponse(): UseResponse {
+  return { namespace: "", database: "" };
+}
+
+export const UseResponse: MessageFns<UseResponse> = {
+  encode(message: UseResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.namespace !== "") {
+      writer.uint32(10).string(message.namespace);
+    }
+    if (message.database !== "") {
+      writer.uint32(18).string(message.database);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UseResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUseResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.namespace = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.database = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UseResponse {
+    return {
+      namespace: isSet(object.namespace) ? globalThis.String(object.namespace) : "",
+      database: isSet(object.database) ? globalThis.String(object.database) : "",
+    };
+  },
+
+  toJSON(message: UseResponse): unknown {
+    const obj: any = {};
+    if (message.namespace !== "") {
+      obj.namespace = message.namespace;
+    }
+    if (message.database !== "") {
+      obj.database = message.database;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UseResponse>, I>>(base?: I): UseResponse {
+    return UseResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UseResponse>, I>>(object: I): UseResponse {
+    const message = createBaseUseResponse();
+    message.namespace = object.namespace ?? "";
+    message.database = object.database ?? "";
+    return message;
+  },
+};
+
+function createBaseSetRequest(): SetRequest {
+  return { name: "", value: undefined };
+}
+
+export const SetRequest: MessageFns<SetRequest> = {
+  encode(message: SetRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.value !== undefined) {
+      Value.encode(message.value, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SetRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSetRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = Value.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SetRequest {
+    return {
+      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      value: isSet(object.value) ? Value.fromJSON(object.value) : undefined,
+    };
+  },
+
+  toJSON(message: SetRequest): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.value !== undefined) {
+      obj.value = Value.toJSON(message.value);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SetRequest>, I>>(base?: I): SetRequest {
+    return SetRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SetRequest>, I>>(object: I): SetRequest {
+    const message = createBaseSetRequest();
+    message.name = object.name ?? "";
+    message.value = (object.value !== undefined && object.value !== null) ? Value.fromPartial(object.value) : undefined;
+    return message;
+  },
+};
+
+function createBaseSetResponse(): SetResponse {
+  return {};
+}
+
+export const SetResponse: MessageFns<SetResponse> = {
+  encode(_: SetResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SetResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSetResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): SetResponse {
+    return {};
+  },
+
+  toJSON(_: SetResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SetResponse>, I>>(base?: I): SetResponse {
+    return SetResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SetResponse>, I>>(_: I): SetResponse {
+    const message = createBaseSetResponse();
+    return message;
+  },
+};
+
+function createBaseUnsetRequest(): UnsetRequest {
+  return { name: "" };
+}
+
+export const UnsetRequest: MessageFns<UnsetRequest> = {
+  encode(message: UnsetRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UnsetRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUnsetRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UnsetRequest {
+    return { name: isSet(object.name) ? globalThis.String(object.name) : "" };
+  },
+
+  toJSON(message: UnsetRequest): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UnsetRequest>, I>>(base?: I): UnsetRequest {
+    return UnsetRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UnsetRequest>, I>>(object: I): UnsetRequest {
+    const message = createBaseUnsetRequest();
+    message.name = object.name ?? "";
+    return message;
+  },
+};
+
+function createBaseUnsetResponse(): UnsetResponse {
+  return {};
+}
+
+export const UnsetResponse: MessageFns<UnsetResponse> = {
+  encode(_: UnsetResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UnsetResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUnsetResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): UnsetResponse {
+    return {};
+  },
+
+  toJSON(_: UnsetResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UnsetResponse>, I>>(base?: I): UnsetResponse {
+    return UnsetResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UnsetResponse>, I>>(_: I): UnsetResponse {
+    const message = createBaseUnsetResponse();
+    return message;
+  },
+};
+
+function createBaseResetRequest(): ResetRequest {
+  return {};
+}
+
+export const ResetRequest: MessageFns<ResetRequest> = {
+  encode(_: ResetRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ResetRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseResetRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): ResetRequest {
+    return {};
+  },
+
+  toJSON(_: ResetRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ResetRequest>, I>>(base?: I): ResetRequest {
+    return ResetRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ResetRequest>, I>>(_: I): ResetRequest {
+    const message = createBaseResetRequest();
+    return message;
+  },
+};
+
+function createBaseResetResponse(): ResetResponse {
+  return {};
+}
+
+export const ResetResponse: MessageFns<ResetResponse> = {
+  encode(_: ResetResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ResetResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseResetResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): ResetResponse {
+    return {};
+  },
+
+  toJSON(_: ResetResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ResetResponse>, I>>(base?: I): ResetResponse {
+    return ResetResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ResetResponse>, I>>(_: I): ResetResponse {
+    const message = createBaseResetResponse();
     return message;
   },
 };
@@ -2472,6 +2982,14 @@ export interface SurrealDBService {
   Signin(request: SigninRequest): Promise<SigninResponse>;
   /** Authenticate a user with a token. */
   Authenticate(request: AuthenticateRequest): Promise<AuthenticateResponse>;
+  /** Use a namespace and database. */
+  Use(request: UseRequest): Promise<UseResponse>;
+  /** Set a global variable for the current session. */
+  Set(request: SetRequest): Promise<SetResponse>;
+  /** Unset a global variable for the current session. */
+  Unset(request: UnsetRequest): Promise<UnsetResponse>;
+  /** Reset all global variables for the current session. */
+  Reset(request: ResetRequest): Promise<ResetResponse>;
   /** Query the database and get a stream of Values. */
   Query(request: QueryRequest): Observable<QueryResponse>;
   /** Issue a live query and get a stream of LiveResponses. */
@@ -2490,6 +3008,10 @@ export class SurrealDBServiceClientImpl implements SurrealDBService {
     this.Signup = this.Signup.bind(this);
     this.Signin = this.Signin.bind(this);
     this.Authenticate = this.Authenticate.bind(this);
+    this.Use = this.Use.bind(this);
+    this.Set = this.Set.bind(this);
+    this.Unset = this.Unset.bind(this);
+    this.Reset = this.Reset.bind(this);
     this.Query = this.Query.bind(this);
     this.Subscribe = this.Subscribe.bind(this);
   }
@@ -2521,6 +3043,30 @@ export class SurrealDBServiceClientImpl implements SurrealDBService {
     const data = AuthenticateRequest.encode(request).finish();
     const promise = this.rpc.request(this.service, "Authenticate", data);
     return promise.then((data) => AuthenticateResponse.decode(new BinaryReader(data)));
+  }
+
+  Use(request: UseRequest): Promise<UseResponse> {
+    const data = UseRequest.encode(request).finish();
+    const promise = this.rpc.request(this.service, "Use", data);
+    return promise.then((data) => UseResponse.decode(new BinaryReader(data)));
+  }
+
+  Set(request: SetRequest): Promise<SetResponse> {
+    const data = SetRequest.encode(request).finish();
+    const promise = this.rpc.request(this.service, "Set", data);
+    return promise.then((data) => SetResponse.decode(new BinaryReader(data)));
+  }
+
+  Unset(request: UnsetRequest): Promise<UnsetResponse> {
+    const data = UnsetRequest.encode(request).finish();
+    const promise = this.rpc.request(this.service, "Unset", data);
+    return promise.then((data) => UnsetResponse.decode(new BinaryReader(data)));
+  }
+
+  Reset(request: ResetRequest): Promise<ResetResponse> {
+    const data = ResetRequest.encode(request).finish();
+    const promise = this.rpc.request(this.service, "Reset", data);
+    return promise.then((data) => ResetResponse.decode(new BinaryReader(data)));
   }
 
   Query(request: QueryRequest): Observable<QueryResponse> {

--- a/surrealdb/protocol/rpc/v1/rpc.proto
+++ b/surrealdb/protocol/rpc/v1/rpc.proto
@@ -19,6 +19,14 @@ service SurrealDBService {
     rpc Signin(SigninRequest) returns (SigninResponse);
     // Authenticate a user with a token.
     rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse);
+    // Use a namespace and database.
+    rpc Use(UseRequest) returns (UseResponse);
+    // Set a global variable for the current session.
+    rpc Set(SetRequest) returns (SetResponse);
+    // Unset a global variable for the current session.
+    rpc Unset(UnsetRequest) returns (UnsetResponse);
+    // Reset all global variables for the current session.
+    rpc Reset(ResetRequest) returns (ResetResponse);
 
     // Query the database and get a stream of Values.
     rpc Query(QueryRequest) returns (stream QueryResponse);
@@ -73,6 +81,50 @@ message AuthenticateRequest {
 message AuthenticateResponse {
     surrealdb.protocol.v1.Value value = 1;
 }
+
+// Request to use a namespace and database.
+message UseRequest {
+    // The namespace to use.
+    // An empty namespace will unset the current namespace.
+    string namespace = 1;
+    // The database to use.
+    // An empty database will unset the current database.
+    string database = 2;
+}
+
+// Response to a use request.
+message UseResponse {
+    // The namespace that is now in use.
+    string namespace = 1;
+    // The database that is now in use.
+    string database = 2;
+}
+
+// Request to set a global variable for the current session.
+message SetRequest {
+    // The name of the variable to set.
+    string name = 1;
+    // The value to set the variable to.
+    surrealdb.protocol.v1.Value value = 2;
+}
+
+// Response to a set request.
+message SetResponse {}
+
+// Request to unset a global variable for the current session.
+message UnsetRequest {
+    // The name of the variable to unset.
+    string name = 1;
+}
+
+// Response to an unset request.
+message UnsetResponse {}
+
+// Request to reset all global variables for the current session.
+message ResetRequest {}
+
+// Response to a reset request.
+message ResetResponse {}
 
 // Request to issue a live query.
 message SubscribeRequest {


### PR DESCRIPTION
This PR adds back the Set, Unset, Reset, and Use rpc methods which don't have exact equivalents in surql.