### PR TITLE
Add flatbuffer generation to makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # Build
 /build
+/plugins
 
 # Rust
 /target


### PR DESCRIPTION
```console
$ make gen
rm -f plugins/protoc-gen-prost
cargo install protoc-gen-prost
    Updating crates.io index
     Ignored package `protoc-gen-prost v0.4.0` is already installed, use --force to override
hash -r
cp /Users/stu/.cargo/bin/protoc-gen-prost plugins/protoc-gen-prost
chmod +x plugins/protoc-gen-prost
rm -f plugins/protoc-gen-tonic
cargo install protoc-gen-tonic
    Updating crates.io index
     Ignored package `protoc-gen-tonic v0.4.1` is already installed, use --force to override
hash -r
cp /Users/stu/.cargo/bin/protoc-gen-tonic plugins/protoc-gen-tonic
chmod +x plugins/protoc-gen-tonic
rm -f plugins/protoc-gen-c
brew install protobuf-c
Warning: protobuf-c 1.5.2 is already installed and up-to-date.
To reinstall 1.5.2, run:
  brew reinstall protobuf-c
hash -r
cp /opt/homebrew/bin/protoc-gen-c plugins/protoc-gen-c
chmod +x plugins/protoc-gen-c
rm -f plugins/protoc-gen-ts_proto
bun install ts-proto
bun add v1.2.9 (9a329c04)

installed ts-proto@2.7.5 with binaries:
 - protoc-gen-ts_proto

[25.00ms] done
ln -s /Users/stu/dev/surrealdb/surrealdb-protocol/node_modules/.bin/protoc-gen-ts_proto /Users/stu/dev/surrealdb/surrealdb-protocol/plugins/protoc-gen-ts_proto
chmod +x plugins/protoc-gen-ts_proto
buf generate
rm -f plugins/flatc
brew install flatbuffers
Warning: flatbuffers 25.2.10 is already installed and up-to-date.
To reinstall 25.2.10, run:
  brew reinstall flatbuffers
hash -r
cp /opt/homebrew/bin/flatc plugins/flatc
chmod +x plugins/flatc
rm -rf gen/rust/fb
mkdir -p gen/rust/fb
plugins/flatc --rust --rust-module-root-file -I /Users/stu/dev/surrealdb/surrealdb-protocol -o gen/rust/fb surrealdb/protocol/v1/value.fbs
```