### PR TITLE
Prepare v0.10.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@surrealdb/protocol",
   "module": "typescript/index.ts",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "license": "BUSL-1.1",
   "licenses": [


### PR DESCRIPTION
## Summary

- Bump `@surrealdb/protocol` version in `package.json` from `0.10.1` → `0.10.2` to match `Cargo.toml` (already bumped in #36).

## Why

The release workflow at `.github/workflows/release.yml` triggers on `v*` tag pushes and runs `publish-rust`, `publish-ts`, and `create-release` in parallel. With the TS package still at `0.10.1`, pushing the `v0.10.2` tag would cause the `publish-ts` job to attempt a duplicate publish of `@surrealdb/protocol@0.10.1` on npm and fail.

This PR aligns the two version sources so a `v0.10.2` tag can be cut cleanly after merge.

## Release steps (after merge)

```bash
git checkout main && git pull
git tag v0.10.2
git push origin v0.10.2
```

The release workflow will then publish to crates.io, npm, and create the GitHub Release.

## Test plan

- [ ] Confirm `package.json` and `Cargo.toml` both report `0.10.2`
- [ ] CI green on this PR
- [ ] After merge + tag push, verify all three release jobs succeed and the new version appears on crates.io and npm